### PR TITLE
Use a FileResource instead of PathElement for easier copy of path created by Resolve

### DIFF
--- a/src/main/java/org/apache/maven/resolver/internal/ant/tasks/Resolve.java
+++ b/src/main/java/org/apache/maven/resolver/internal/ant/tasks/Resolve.java
@@ -294,7 +294,8 @@ public class Resolve
                 path = new org.apache.tools.ant.types.Path( getProject() );
                 getProject().addReference( refid, path );
             }
-            path.setLocation( artifact.getFile() );
+            File file = artifact.getFile();
+            path.add( new FileResource( file.getParentFile(), file.getName() ) );
         }
 
     }


### PR DESCRIPTION
Because Maven artifacts are added using an absolute path in the Resolve task, it makes copying them around rather tedious, as you have to use the flatten attribute to discard the full path.

This PR replaces PathElement with FileResource, which allows to separate the base directory from the file name and make default copy work out of the box.