### PR TITLE
[MRESOLVER-66] settings task does not load repositories defined into settings.xml

### DIFF
--- a/src/main/java/org/apache/maven/resolver/internal/ant/AntRepoSys.java
+++ b/src/main/java/org/apache/maven/resolver/internal/ant/AntRepoSys.java
@@ -352,7 +352,7 @@ public class AntRepoSys
         }
 
         org.eclipse.aether.repository.LocalRepository repo =
-            new org.eclipse.aether.repository.LocalRepository( repoDir );
+            new org.eclipse.aether.repository.LocalRepository( repoDir, "simple" );
 
         return getSystem().newLocalRepositoryManager( session, repo );
     }


### PR DESCRIPTION
Cascade error from the LocalRepository being created "enhanced" and DefaultArtifactResolver expecting that maven-metadata-local.xml is present.