### PR TITLE
Attempt to update Ant to latest 1.10

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -68,7 +68,7 @@
     </resolver:resolve>
 
     <javac classpathref="cp.compile.main" srcdir="src/main/java" destdir="${build.dir}/classes"
-           includeAntRuntime="false" source="7" target="7" encoding="UTF-8" fork="true"/>
+           includeAntRuntime="false" source="8" target="8" encoding="UTF-8" fork="true"/>
   </target>
 
   <target name="process-test-resources" depends="compile">
@@ -91,7 +91,7 @@
     </path>
 
     <javac classpathref="cp.test" srcdir="src/test/java" destdir="${build.dir}/test-classes"
-           includeAntRuntime="false" source="7" target="7" encoding="UTF-8" fork="true"/>
+           includeAntRuntime="false" source="8" target="8" encoding="UTF-8" fork="true"/>
   </target>
 
   <target name="test" depends="test-compile">

--- a/pom.xml
+++ b/pom.xml
@@ -61,10 +61,11 @@
   </distributionManagement>
 
   <properties>
-    <mavenVersion>3.6.3</mavenVersion>
+    <mavenVersion>3.8.3</mavenVersion>
     <resolverVersion>1.7.2</resolverVersion>
-    <antVersion>1.8.4</antVersion>
+    <antVersion>1.10.12</antVersion>
     <javaVersion>8</javaVersion>
+    <junitVersion>4.13.2</junitVersion>
     <maven.site.path>resolver-archives/resolver-ant-tasks-LATEST</maven.site.path>
     <checkstyle.violation.ignore>LineLength,MagicNumber</checkstyle.violation.ignore>
     <project.build.outputTimestamp>2021-05-13T18:07:07Z</project.build.outputTimestamp>
@@ -78,9 +79,9 @@
         <version>3.2.0</version>
       </dependency>
       <dependency>
-        <groupId>org.sonatype.plexus</groupId>
+        <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-cipher</artifactId>
-        <version>1.7</version>
+        <version>2.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -138,7 +139,7 @@
       <!-- This shuts off annoying warnings from slf4j-api -->
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-nop</artifactId>
-      <version>1.7.25</version>
+      <version>1.7.30</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -166,11 +167,6 @@
           <artifactId>plexus-component-annotations</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-component-annotations</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
@@ -211,7 +207,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>${junitVersion}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -271,8 +267,9 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.2.3</version>
+        <version>3.2.4</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -363,8 +360,18 @@
             <dependencies>
               <dependency>
                 <groupId>org.apache.ant</groupId>
+                <artifactId>ant</artifactId>
+                <version>${antVersion}</version>
+              </dependency>
+              <dependency>
+                <groupId>org.apache.ant</groupId>
                 <artifactId>ant-junit</artifactId>
                 <version>${antVersion}</version>
+              </dependency>
+              <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>${junitVersion}</version>
               </dependency>
             </dependencies>
           </plugin>

--- a/src/main/java/org/apache/maven/resolver/internal/ant/AntSecDispatcher.java
+++ b/src/main/java/org/apache/maven/resolver/internal/ant/AntSecDispatcher.java
@@ -20,8 +20,9 @@ package org.apache.maven.resolver.internal.ant;
  */
 
 import org.sonatype.plexus.components.cipher.DefaultPlexusCipher;
-import org.sonatype.plexus.components.cipher.PlexusCipherException;
 import org.sonatype.plexus.components.sec.dispatcher.DefaultSecDispatcher;
+
+import java.util.Collections;
 
 /**
  */
@@ -31,15 +32,7 @@ class AntSecDispatcher
 
     AntSecDispatcher()
     {
-        _configurationFile = "~/.m2/settings-security.xml";
-        try
-        {
-            _cipher = new DefaultPlexusCipher();
-        }
-        catch ( PlexusCipherException e )
-        {
-            e.printStackTrace();
-        }
+        super(new DefaultPlexusCipher(), Collections.emptyMap(), "~/.m2/settings-security.xml");
     }
 
 }

--- a/src/main/java/org/apache/maven/resolver/internal/ant/AntSecDispatcher.java
+++ b/src/main/java/org/apache/maven/resolver/internal/ant/AntSecDispatcher.java
@@ -32,7 +32,7 @@ class AntSecDispatcher
 
     AntSecDispatcher()
     {
-        super(new DefaultPlexusCipher(), Collections.emptyMap(), "~/.m2/settings-security.xml");
+        super( new DefaultPlexusCipher(), Collections.emptyMap(), "~/.m2/settings-security.xml" );
     }
 
 }

--- a/src/test/java/org/apache/maven/resolver/internal/ant/AntBuildsTest.java
+++ b/src/test/java/org/apache/maven/resolver/internal/ant/AntBuildsTest.java
@@ -39,6 +39,8 @@ public abstract class AntBuildsTest
 
     static
     {
+        System.setProperty("aether.metadataResolver.threads", "1");
+        System.setProperty("aether.connector.basic.threads", "1");
         BASE_DIR = new File( "" ).getAbsoluteFile();
         BUILD_DIR = new File( BASE_DIR, "target/ant" );
     }

--- a/src/test/java/org/apache/maven/resolver/internal/ant/DeployTest.java
+++ b/src/test/java/org/apache/maven/resolver/internal/ant/DeployTest.java
@@ -19,6 +19,9 @@ package org.apache.maven.resolver.internal.ant;
  * under the License.
  */
 
+import junit.framework.JUnit4TestAdapter;
+import org.junit.Test;
+
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
 
@@ -32,7 +35,11 @@ import java.util.Arrays;
 public class DeployTest
     extends AntBuildsTest
 {
+    public static junit.framework.Test suite() {
+        return new JUnit4TestAdapter(DeployTest.class);
+    }
 
+    @Test
     public void testDeployGlobalPom()
     {
         long min = System.currentTimeMillis();
@@ -44,6 +51,7 @@ public class DeployTest
         assertUpdatedFile( min, max, distRepoDir, "test/dummy/0.1-SNAPSHOT/maven-metadata.xml" );
     }
 
+    @Test
     public void testDeployOverrideGlobalPom()
     {
         long min = System.currentTimeMillis();
@@ -55,6 +63,7 @@ public class DeployTest
         assertUpdatedFile( min, max, distRepoDir, "test/other/0.1-SNAPSHOT/maven-metadata.xml" );
     }
 
+    @Test
     public void testDeployOverrideGlobalPomByRef()
     {
         long min = System.currentTimeMillis();
@@ -67,6 +76,7 @@ public class DeployTest
         assertUpdatedFile( min, max, distRepoDir, "test/other/0.1-SNAPSHOT/maven-metadata.xml" );
     }
 
+    @Test
     public void testDeployAttachedArtifact()
     {
         executeTarget( "testDeployAttachedArtifact" );

--- a/src/test/java/org/apache/maven/resolver/internal/ant/InstallTest.java
+++ b/src/test/java/org/apache/maven/resolver/internal/ant/InstallTest.java
@@ -19,6 +19,9 @@ package org.apache.maven.resolver.internal.ant;
  * under the License.
  */
 
+import junit.framework.JUnit4TestAdapter;
+import org.junit.Test;
+
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
 
@@ -28,7 +31,11 @@ import java.io.IOException;
 public class InstallTest
     extends AntBuildsTest
 {
+    public static junit.framework.Test suite() {
+        return new JUnit4TestAdapter(InstallTest.class);
+    }
 
+    @Test
     public void testInstallGlobalPom()
     {
         executeTarget( "testInstallGlobalPom" );
@@ -39,6 +46,7 @@ public class InstallTest
         assertUpdatedFile( tstamp, localRepoDir, "test/dummy/0.1-SNAPSHOT/dummy-0.1-SNAPSHOT.pom" );
     }
 
+    @Test
     public void testInstallOverrideGlobalPom()
     {
         executeTarget( "testInstallOverrideGlobalPom" );
@@ -49,6 +57,7 @@ public class InstallTest
         assertUpdatedFile( tstamp, localRepoDir, "test/other/0.1-SNAPSHOT/other-0.1-SNAPSHOT.pom" );
     }
 
+    @Test
     public void testInstallOverrideGlobalPomByRef()
     {
         long tstamp = System.currentTimeMillis();
@@ -60,6 +69,7 @@ public class InstallTest
         assertUpdatedFile( tstamp, localRepoDir, "test/other/0.1-SNAPSHOT/other-0.1-SNAPSHOT.pom" );
     }
 
+    @Test
     public void testDefaultRepo()
     {
         executeTarget( "testDefaultRepo" );
@@ -71,6 +81,7 @@ public class InstallTest
         assertUpdatedFile( tstamp, localRepoDir, "test/dummy/0.1-SNAPSHOT/dummy-0.1-SNAPSHOT-ant.xml" );
     }
 
+    @Test
     public void testCustomRepo()
         throws IOException
     {

--- a/src/test/java/org/apache/maven/resolver/internal/ant/ProjectWorkspaceReaderTest.java
+++ b/src/test/java/org/apache/maven/resolver/internal/ant/ProjectWorkspaceReaderTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.*;
 
 import java.io.File;
 
-import org.apache.maven.resolver.internal.ant.ProjectWorkspaceReader;
+import junit.framework.JUnit4TestAdapter;
 import org.apache.maven.resolver.internal.ant.types.Pom;
 import org.apache.tools.ant.Project;
 import org.junit.Before;
@@ -34,6 +34,9 @@ import org.eclipse.aether.artifact.DefaultArtifact;
 
 public class ProjectWorkspaceReaderTest
 {
+    public static junit.framework.Test suite() {
+        return new JUnit4TestAdapter(ProjectWorkspaceReaderTest.class);
+    }
 
     private ProjectWorkspaceReader reader;
 

--- a/src/test/java/org/apache/maven/resolver/internal/ant/ReactorTest.java
+++ b/src/test/java/org/apache/maven/resolver/internal/ant/ReactorTest.java
@@ -22,19 +22,27 @@ package org.apache.maven.resolver.internal.ant;
 import java.io.File;
 import java.io.IOException;
 
+import junit.framework.JUnit4TestAdapter;
 import org.apache.maven.resolver.internal.ant.ProjectWorkspaceReader;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 public class ReactorTest
     extends AntBuildsTest
 {
+    public static junit.framework.Test suite() {
+        return new JUnit4TestAdapter(ReactorTest.class);
+    }
 
     private Artifact artifact( String coords )
     {
         return new DefaultArtifact( coords );
     }
 
+    @Test
     public void testPom()
         throws IOException
     {
@@ -45,6 +53,7 @@ public class ReactorTest
         assertEquals( new File( projectDir, "pom1.xml" ), found.getAbsoluteFile() );
     }
 
+    @Test
     public void testArtifact()
         throws IOException
     {
@@ -59,6 +68,7 @@ public class ReactorTest
         assertEquals( new File( projectDir, "pom1.xml" ), found.getAbsoluteFile() );
     }
 
+    @Test
     public void testArtifactInMemoryPom()
         throws IOException
     {
@@ -72,28 +82,31 @@ public class ReactorTest
         assertEquals( new File( projectDir, "pom1.xml" ), found.getAbsoluteFile() );
     }
 
+    @Test
     public void testResolveArtifact()
         throws IOException
     {
         executeTarget( "testResolveArtifact" );
-        String prop = project.getProperty( "resolve.test:test:jar" );
+        String prop = getProject().getProperty( "resolve.test:test:jar" );
         assertEquals( new File( projectDir, "pom1.xml" ).getAbsolutePath(), prop );
     }
 
+    @Test
     public void testResolveArtifactInMemoryPom()
         throws IOException
     {
         executeTarget( "testResolveArtifactInMemoryPom" );
-        String prop = project.getProperty( "resolve.test:test:jar" );
+        String prop = getProject().getProperty( "resolve.test:test:jar" );
         assertEquals( new File( projectDir, "pom1.xml" ).getAbsolutePath(), prop );
         assertLogContaining( "The POM for test:test:jar:0.1-SNAPSHOT is missing, no dependency information available" );
     }
 
+    @Test
     public void testResolveVersionRange()
         throws IOException
     {
         executeTarget( "testResolveVersionRange" );
-        String prop = project.getProperty( "resolve.test:test:jar" );
+        String prop = getProject().getProperty( "resolve.test:test:jar" );
         assertEquals( new File( projectDir, "pom1.xml" ).getAbsolutePath(), prop );
     }
 

--- a/src/test/java/org/apache/maven/resolver/internal/ant/ResolveTest.java
+++ b/src/test/java/org/apache/maven/resolver/internal/ant/ResolveTest.java
@@ -28,14 +28,20 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
 
+import junit.framework.JUnit4TestAdapter;
 import org.apache.tools.ant.types.Path;
 import org.apache.tools.ant.types.ResourceCollection;
 import org.apache.tools.ant.types.resources.FileResource;
+import org.junit.Test;
 
 public class ResolveTest
     extends AntBuildsTest
 {
+    public static junit.framework.Test suite() {
+        return new JUnit4TestAdapter(ResolveTest.class);
+    }
 
+    @Test
     public void testResolveGlobalPom()
     {
         executeTarget( "testResolveGlobalPom" );
@@ -46,6 +52,7 @@ public class ResolveTest
                     allOf( containsString( "aether-api" ), endsWith( ".jar" ) ) );
     }
 
+    @Test
     public void testResolveOverrideGlobalPom()
     {
         executeTarget( "testResolveOverrideGlobalPom" );
@@ -56,6 +63,7 @@ public class ResolveTest
                     allOf( containsString( "aether-api" ), endsWith( ".jar" ) ) );
     }
 
+    @Test
     public void testResolveGlobalPomIntoOtherLocalRepo()
     {
         executeTarget( "testResolveGlobalPomIntoOtherLocalRepo" );
@@ -66,6 +74,7 @@ public class ResolveTest
                     endsWith( "local-repo-custom/org/eclipse/aether/aether-api/0.9.0.M3/aether-api-0.9.0.M3.jar" ) );
     }
 
+    @Test
     public void testResolveCustomFileLayout()
         throws IOException
     {
@@ -76,6 +85,7 @@ public class ResolveTest
                     new File( dir, "org.eclipse.aether/aether-api/org/eclipse/aether/jar" ).exists() );
     }
 
+    @Test
     public void testResolveAttachments()
         throws IOException
     {
@@ -96,6 +106,7 @@ public class ResolveTest
                     everyItem( endsWith( "sources.jar" ) ) );
     }
 
+    @Test
     public void testResolvePath()
     {
         executeTarget( "testResolvePath" );
@@ -108,6 +119,7 @@ public class ResolveTest
                     hasItemInArray( allOf( containsString( "aether-api" ), endsWith( ".jar" ) ) ) );
     }
 
+    @Test
     public void testResolveDepsFromFile()
     {
         executeTarget( "testResolveDepsFromFile" );
@@ -120,6 +132,7 @@ public class ResolveTest
         assertThat( "aether-api was resolved as a property", prop, nullValue() );
     }
 
+    @Test
     public void testResolveNestedDependencyCollections()
     {
         executeTarget( "testResolveNestedDependencyCollections" );
@@ -132,6 +145,7 @@ public class ResolveTest
         assertThat( "aether-api was resolved as a property", prop, nullValue() );
     }
 
+    @Test
     public void testResolveResourceCollectionOnly()
     {
         executeTarget( "testResolveResourceCollectionOnly" );

--- a/src/test/java/org/apache/maven/resolver/internal/ant/SettingsTest.java
+++ b/src/test/java/org/apache/maven/resolver/internal/ant/SettingsTest.java
@@ -25,12 +25,17 @@ import static org.hamcrest.Matchers.*;
 import java.io.File;
 import java.io.IOException;
 
-import org.apache.maven.resolver.internal.ant.AntRepoSys;
+import junit.framework.JUnit4TestAdapter;
+import org.junit.Test;
 
 public class SettingsTest
     extends AntBuildsTest
 {
+    public static junit.framework.Test suite() {
+        return new JUnit4TestAdapter(SettingsTest.class);
+    }
 
+    @Test
     public void testUserSettings()
     {
         executeTarget( "testUserSettings" );
@@ -38,6 +43,7 @@ public class SettingsTest
                     equalTo( "userSettings.xml" ) );
     }
 
+    @Test
     public void testGlobalSettings()
     {
         executeTarget( "testGlobalSettings" );
@@ -45,6 +51,7 @@ public class SettingsTest
                     equalTo( "globalSettings.xml" ) );
     }
 
+    @Test
     public void testBothSettings()
     {
         executeTarget( "testBothSettings" );
@@ -54,6 +61,7 @@ public class SettingsTest
                     equalTo( "userSettings.xml" ) );
     }
 
+    @Test
     public void testFallback()
         throws IOException
     {

--- a/src/test/java/org/apache/maven/resolver/internal/ant/tasks/LayoutTest.java
+++ b/src/test/java/org/apache/maven/resolver/internal/ant/tasks/LayoutTest.java
@@ -21,7 +21,7 @@ package org.apache.maven.resolver.internal.ant.tasks;
 
 import static org.junit.Assert.assertEquals;
 
-import org.apache.maven.resolver.internal.ant.tasks.Layout;
+import junit.framework.JUnit4TestAdapter;
 import org.apache.tools.ant.BuildException;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.junit.Test;
@@ -30,6 +30,9 @@ import org.junit.Test;
  */
 public class LayoutTest
 {
+    public static junit.framework.Test suite() {
+        return new JUnit4TestAdapter(LayoutTest.class);
+    }
 
     @Test( expected = BuildException.class )
     public void testUnknownVariable()

--- a/src/test/java/org/apache/maven/resolver/internal/ant/types/DependencyTest.java
+++ b/src/test/java/org/apache/maven/resolver/internal/ant/types/DependencyTest.java
@@ -21,13 +21,16 @@ package org.apache.maven.resolver.internal.ant.types;
 
 import static org.junit.Assert.*;
 
-import org.apache.maven.resolver.internal.ant.types.Dependency;
+import junit.framework.JUnit4TestAdapter;
 import org.junit.Test;
 
 /**
  */
 public class DependencyTest
 {
+    public static junit.framework.Test suite() {
+        return new JUnit4TestAdapter(DependencyTest.class);
+    }
 
     @Test
     public void testSetCoordsGidAidVer()

--- a/src/test/java/org/apache/maven/resolver/internal/ant/types/ExclusionTest.java
+++ b/src/test/java/org/apache/maven/resolver/internal/ant/types/ExclusionTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.resolver.internal.ant.types;
 
 import static org.junit.Assert.*;
 
+import junit.framework.JUnit4TestAdapter;
 import org.apache.maven.resolver.internal.ant.types.Exclusion;
 import org.junit.Test;
 
@@ -28,6 +29,9 @@ import org.junit.Test;
  */
 public class ExclusionTest
 {
+    public static junit.framework.Test suite() {
+        return new JUnit4TestAdapter(ExclusionTest.class);
+    }
 
     @Test
     public void testSetCoordsGid()

--- a/src/test/java/org/apache/maven/resolver/internal/ant/types/PomTest.java
+++ b/src/test/java/org/apache/maven/resolver/internal/ant/types/PomTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.resolver.internal.ant.types;
 
 import static org.junit.Assert.*;
 
+import junit.framework.JUnit4TestAdapter;
 import org.apache.maven.resolver.internal.ant.types.Pom;
 import org.junit.Test;
 
@@ -28,6 +29,9 @@ import org.junit.Test;
  */
 public class PomTest
 {
+    public static junit.framework.Test suite() {
+        return new JUnit4TestAdapter(PomTest.class);
+    }
 
     @Test
     public void testSetCoordsGid()


### PR DESCRIPTION
The code deadlocks, as now BuildFileRule is used that syncs on
System.out but resolver uses by default 5 threads to resolve and
deadlocks on logging.