### PR TITLE
[MRESOLVER-98] Add support for dependency management

### DIFF
--- a/src/test/java/org/apache/maven/resolver/internal/ant/ResolveTest.java
+++ b/src/test/java/org/apache/maven/resolver/internal/ant/ResolveTest.java
@@ -162,4 +162,26 @@ public class ResolveTest
         assertThat( file.getFile().getName(), is( "aether-api-0.9.0.v20140226.jar" ) );
     }
 
+    @Test
+    public void testResolveDependencyManagement()
+    {
+        executeTarget( "testResolveDependencyManagement" );
+        Map<?, ?> refs = getProject().getReferences();
+
+        Object obj = refs.get( "depMgmt.compile" );
+        assertThat( "ref 'depMgmt.compile' is no path", obj, instanceOf( Path.class ) );
+        Path path = (Path) obj;
+        String[] elements = path.list();
+        assertThat( "commons-pool2 on compile classpath", elements,
+                    not( hasItemInArray( containsString("commons-pool2") ) ) );
+
+        obj = refs.get( "depMgmt.test" );
+        assertThat( "ref 'depMgmt.test' is no path", obj, instanceOf( Path.class ) );
+        path = (Path) obj;
+        elements = path.list();
+        assertThat( "no commons-dbcp2 version 2.9.0 on test classpath", elements,
+                    hasItemInArray( endsWith("commons-dbcp2-2.9.0.jar") ) );
+        assertThat( "no commons-pool2 version 2.11.1 on test classpath", elements,
+                hasItemInArray( endsWith("commons-pool2-2.11.1.jar") ) );
+    }
 }

--- a/src/test/resources/ant/Resolve/ant.xml
+++ b/src/test/resources/ant/Resolve/ant.xml
@@ -119,4 +119,11 @@
     </repo:resolve>
   </target>
 
+  <target name="testResolveDependencyManagement">
+    <repo:pom file="${project.dir}/pom.xml"/>
+    <repo:resolve>
+      <path refid="depMgmt.compile" classpath="compile"/>
+      <path refid="depMgmt.test" classpath="test"/>
+    </repo:resolve>
+  </target>
 </project>

--- a/src/test/resources/ant/Resolve/pom.xml
+++ b/src/test/resources/ant/Resolve/pom.xml
@@ -37,6 +37,16 @@
     <aetherVersion>0.9.0.M3</aetherVersion>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-pool2</artifactId>
+        <version>2.11.1</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.eclipse.aether</groupId>
@@ -50,6 +60,12 @@
       <type>pom</type>
       <scope>system</scope>
       <systemPath>${basedir}/pom.xml</systemPath>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-dbcp2</artifactId>
+      <version>2.9.0</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
This PR adds support for dependency management of transitive dependencies. The support is limited to metadata coming from a POM file.

Due to the way `<scope>` is treated in the dependency management section (`null` does not mean `compile`) the conversion between Maven's `Dependency` and Aeter's `Dependency` is performed directly, without converting it to Ant's `Dependency` first.