### PR TITLE
[MRESOLVER-402] Fix property handling

### DIFF
--- a/src/main/java/org/apache/maven/resolver/internal/ant/AntRepoSys.java
+++ b/src/main/java/org/apache/maven/resolver/internal/ant/AntRepoSys.java
@@ -27,6 +27,7 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -103,6 +104,7 @@ import org.eclipse.aether.util.repository.DefaultProxySelector;
 /**
  */
 public class AntRepoSys {
+    private static final Date STARTED = new Date();
 
     private static final boolean OS_WINDOWS = Os.isFamily("windows");
 
@@ -183,10 +185,12 @@ public class AntRepoSys {
 
         final Map<Object, Object> configProps = new LinkedHashMap<>();
         configProps.put(ConfigurationProperties.USER_AGENT, getUserAgent());
+        configProps.put("maven.startTime", STARTED);
+        configProps.putAll(System.getProperties());
         configProps.putAll(project.getProperties());
         processServerConfiguration(configProps);
-        session.setConfigProperties(configProps);
 
+        session.setConfigProperties(configProps);
         session.setSystemProperties(System.getProperties());
         session.setUserProperties(project.getUserProperties());
         session.setOffline(isOffline());

--- a/src/main/java/org/apache/maven/resolver/internal/ant/AntRepoSys.java
+++ b/src/main/java/org/apache/maven/resolver/internal/ant/AntRepoSys.java
@@ -186,13 +186,13 @@ public class AntRepoSys {
         final Map<Object, Object> configProps = new LinkedHashMap<>();
         configProps.put(ConfigurationProperties.USER_AGENT, getUserAgent());
         configProps.put("maven.startTime", STARTED);
-        configProps.putAll(System.getProperties());
-        configProps.putAll(project.getProperties());
+        configProps.putAll(getSystemProperties());
+        configProps.putAll(getUserProperties());
         processServerConfiguration(configProps);
 
         session.setConfigProperties(configProps);
-        session.setSystemProperties(System.getProperties());
-        session.setUserProperties(project.getUserProperties());
+        session.setSystemProperties(getSystemProperties());
+        session.setUserProperties(getUserProperties());
         session.setOffline(isOffline());
 
         session.setProxySelector(getProxySelector());


### PR DESCRIPTION
Properties are laid down as (former may be overridden by latter):
* internally mandatory ones (UA, startTime)
* Java System Properties
* Ant project properties (all Ant project properties that has all)

Fixes issue where Java System Properties were not present in Resolver config properties (Resolver strictly observes config properties only), and added missing one.