### PR TITLE
Don't default the scope of managed dependencies to 'compile'

### DIFF
--- a/src/main/java/org/apache/maven/resolver/internal/ant/AntRepoSys.java
+++ b/src/main/java/org/apache/maven/resolver/internal/ant/AntRepoSys.java
@@ -654,7 +654,7 @@ public class AntRepoSys {
                         dependency.addExclusion(exclusion);
                     }
                     collectRequest.addManagedDependency(
-                            ConverterUtils.toDependency(dependency, globalExclusions, session));
+                            ConverterUtils.toManagedDependency(dependency, globalExclusions, session));
                 }
             }
 

--- a/src/main/java/org/apache/maven/resolver/internal/ant/ConverterUtils.java
+++ b/src/main/java/org/apache/maven/resolver/internal/ant/ConverterUtils.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.maven.resolver.internal.ant.types.Authentication;
 import org.apache.maven.resolver.internal.ant.types.Dependency;
 import org.apache.maven.resolver.internal.ant.types.Exclusion;
@@ -82,6 +83,16 @@ class ConverterUtils {
 
     public static org.eclipse.aether.graph.Dependency toDependency(
             Dependency dependency, List<Exclusion> exclusions, RepositorySystemSession session) {
+        String scope = dependency.getScope();
+        return new org.eclipse.aether.graph.Dependency(
+                toArtifact(dependency, session.getArtifactTypeRegistry()),
+                ObjectUtils.isEmpty(scope) ? "compile" : scope,
+                false,
+                toExclusions(dependency.getExclusions(), exclusions));
+    }
+
+    public static org.eclipse.aether.graph.Dependency toManagedDependency(
+        Dependency dependency, List<Exclusion> exclusions, RepositorySystemSession session) {
         return new org.eclipse.aether.graph.Dependency(
                 toArtifact(dependency, session.getArtifactTypeRegistry()),
                 dependency.getScope(),

--- a/src/main/java/org/apache/maven/resolver/internal/ant/types/Dependency.java
+++ b/src/main/java/org/apache/maven/resolver/internal/ant/types/Dependency.java
@@ -188,7 +188,7 @@ public class Dependency extends DataType implements DependencyContainer {
         if (isReference()) {
             return getRef().getScope();
         }
-        return (scope != null) ? scope : "compile";
+        return (scope != null) ? scope : "";
     }
 
     public void setScope(String scope) {

--- a/src/test/java/org/apache/maven/resolver/internal/ant/ResolveTest.java
+++ b/src/test/java/org/apache/maven/resolver/internal/ant/ResolveTest.java
@@ -177,4 +177,23 @@ public class ResolveTest extends AntBuildsTest {
                 prop,
                 allOf(containsString("apiguardian-api"), endsWith("apiguardian-api-1.1.1.jar")));
     }
+
+    @Test
+    public void testResolveTransitiveDependencyManagementTestScope() {
+        executeTarget("testResolveTransitiveDependencyManagementTestScope");
+
+        String prop = getProject().getProperty("test.compile.resolve.path.org.slf4j:slf4j-api:jar");
+        assertThat("slf4j-api was not resolved as a property", prop, notNullValue());
+        assertThat(
+                "slf4j-api was not resolved to default local repository",
+                prop,
+                allOf(containsString("slf4j-api"), endsWith("slf4j-api-2.0.6.jar")));
+
+        prop = getProject().getProperty("test.resolve.path.org.apiguardian:apiguardian-api:jar");
+        assertThat("apiguardian-api was not resolved as a property", prop, notNullValue());
+        assertThat(
+                "apiguardian-api was not resolved to default local repository",
+                prop,
+                allOf(containsString("apiguardian-api"), endsWith("apiguardian-api-1.1.1.jar")));
+    }
 }

--- a/src/test/java/org/apache/maven/resolver/internal/ant/types/DependencyTest.java
+++ b/src/test/java/org/apache/maven/resolver/internal/ant/types/DependencyTest.java
@@ -40,7 +40,7 @@ public class DependencyTest {
         assertEquals("ver", dep.getVersion());
         assertEquals("jar", dep.getType());
         assertEquals("", dep.getClassifier());
-        assertEquals("compile", dep.getScope());
+        assertEquals("", dep.getScope());
     }
 
     @Test

--- a/src/test/resources/ant/Resolve/ant.xml
+++ b/src/test/resources/ant/Resolve/ant.xml
@@ -122,8 +122,18 @@
   <target name="testResolveTransitiveDependencyManagement">
     <repo:pom file="${project.dir}/transitive-depmgt-pom.xml"/>
     <repo:resolve>
-      <properties prefix="test.resolve.path" classpath="compile"/>
+      <properties prefix="test.resolve.path" classpath="test"/>
     </repo:resolve>
   </target>
+
+  <target name="testResolveTransitiveDependencyManagementTestScope">
+    <repo:pom file="${project.dir}/transitive-depmgt-pom.xml"/>
+    <repo:resolve>
+      <properties prefix="test.compile.resolve.path" scopes="compile"/>
+      <properties prefix="test.compile.resolve.classpath" classpath="compile"/>
+      <properties prefix="test.resolve.path" scopes="test"/>
+      <properties prefix="test.resolve.classpath" classpath="test"/>
+    </repo:resolve>
+  </target>	
 
 </project>


### PR DESCRIPTION
If a scope isn't defined in a managed dependency, the scope specified in the dependency section is used for resolving transitive dependencies.

I thought that letting the maven-resolver classes do all defaulting would have worked, but without defaulting the scope of the other dependencies created by ConverterUtils.toDependency, ResolveTest.testResolveNestedDependencyCollections() fails. Removing this defaulting still seems like it might be the right thing to do, but I'm not pulling on this thread. I don't know what it is attached to.