### PR TITLE
Update Resolver/Maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,8 +57,8 @@
   </distributionManagement>
 
   <properties>
-    <mavenVersion>3.9.10</mavenVersion>
-    <resolverVersion>1.9.23</resolverVersion>
+    <mavenVersion>3.9.11-SNAPSHOT</mavenVersion>
+    <resolverVersion>1.9.24-SNAPSHOT</resolverVersion>
     <antVersion>1.10.15</antVersion>
     <javaVersion>8</javaVersion>
     <junitVersion>4.13.2</junitVersion>
@@ -302,6 +302,7 @@
                     <exclude>META-INF/NOTICE.txt</exclude>
                     <exclude>META-INF/DEPENDENCIES</exclude>
                     <exclude>META-INF/MANIFEST.MF</exclude>
+                    <exclude>META-INF/versions/*/module-info.class</exclude>
                   </excludes>
                 </filter>
               </filters>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
 
   <properties>
     <mavenVersion>3.9.11-SNAPSHOT</mavenVersion>
-    <resolverVersion>1.9.24-SNAPSHOT</resolverVersion>
+    <resolverVersion>1.9.24</resolverVersion>
     <antVersion>1.10.15</antVersion>
     <javaVersion>8</javaVersion>
     <junitVersion>4.13.2</junitVersion>
@@ -181,32 +181,6 @@
     <dependency>
       <groupId>org.eclipse.sisu</groupId>
       <artifactId>org.eclipse.sisu.plexus</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>javax.enterprise</groupId>
-          <artifactId>cdi-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-classworlds</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-utils</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.eclipse.sisu</groupId>
-          <artifactId>org.eclipse.sisu.inject</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.sonatype.sisu</groupId>
-          <artifactId>sisu-guice</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
   </distributionManagement>
 
   <properties>
-    <mavenVersion>3.9.11-SNAPSHOT</mavenVersion>
+    <mavenVersion>3.9.10</mavenVersion>
     <resolverVersion>1.9.24</resolverVersion>
     <antVersion>1.10.15</antVersion>
     <javaVersion>8</javaVersion>

--- a/src/main/java/org/apache/maven/resolver/internal/ant/AntRepoSys.java
+++ b/src/main/java/org/apache/maven/resolver/internal/ant/AntRepoSys.java
@@ -159,7 +159,7 @@ public class AntRepoSys {
         RemoteRepository repo = new RemoteRepository();
         repo.setProject(project);
         repo.setId("central");
-        repo.setUrl("https://repo1.maven.org/maven2/");
+        repo.setUrl("https://repo.maven.apache.org/maven2/");
         project.addReference(Names.ID_CENTRAL, repo);
 
         repo = new RemoteRepository();

--- a/src/main/java/org/apache/maven/resolver/internal/ant/AntTransferListener.java
+++ b/src/main/java/org/apache/maven/resolver/internal/ant/AntTransferListener.java
@@ -43,6 +43,8 @@ class AntTransferListener extends AbstractTransferListener {
     @Override
     public void transferInitiated(final TransferEvent event) throws TransferCancelledException {
         String msg = event.getRequestType() == TransferEvent.RequestType.PUT ? "Uploading" : "Downloading";
+        msg += event.getRequestType() == TransferEvent.RequestType.PUT ? " to" : " from";
+        msg += " " + event.getResource().getRepositoryId();
         msg += " " + event.getResource().getRepositoryUrl()
                 + event.getResource().getResourceName();
         task.log(msg);
@@ -60,6 +62,8 @@ class AntTransferListener extends AbstractTransferListener {
     @Override
     public void transferSucceeded(final TransferEvent event) {
         String msg = event.getRequestType() == TransferEvent.RequestType.PUT ? "Uploaded" : "Downloaded";
+        msg += event.getRequestType() == TransferEvent.RequestType.PUT ? " to" : " from";
+        msg += " " + event.getResource().getRepositoryId();
         msg += " " + event.getResource().getRepositoryUrl()
                 + event.getResource().getResourceName();
 

--- a/src/test/resources/ant/Resolve/ant.xml
+++ b/src/test/resources/ant/Resolve/ant.xml
@@ -27,9 +27,9 @@
 
   &common;
 
-  <repo:remoterepo id="remote" url="https://repo1.maven.org/maven2" type="default" releases="true" snapshots="true" updates="always" checksums="fail"/>
+  <repo:remoterepo id="central" url="https://repo.maven.apache.org/maven2/" type="default" releases="true" snapshots="false" updates="daily" checksums="fail"/>
   <repo:remoterepos id="resolver.repositories">
-    <repo:remoterepo refid="remote"/>
+    <repo:remoterepo refid="central"/>
   </repo:remoterepos>
 
   <target name="setUp">


### PR DESCRIPTION
Once 1.9.24 and 3.9.11 is out.

Changes:
* Maven 3.9.11
* Resolver 1.9.24
* shade: do not warn
* use proper Maven Central URL (not the archaic one)
* enhance resolver messages (upload/download added from/to)
* fix nonsensical "remote" repo def