### PR TITLE
Skip activeProfiles not defined in settings.xml (#166)

### DIFF
--- a/src/main/java/org/apache/maven/resolver/internal/ant/AntRepoSys.java
+++ b/src/main/java/org/apache/maven/resolver/internal/ant/AntRepoSys.java
@@ -488,6 +488,10 @@ public class AntRepoSys {
         List<String> activeProfiles = settings.getActiveProfiles();
         for (String profileId : activeProfiles) {
             Profile profile = settings.getProfilesAsMap().get(profileId);
+            if (profile == null) {
+                project.log("Profile '" + profileId + "' is not defined in settings.xml, skipping", Project.MSG_WARN);
+                continue;
+            }
             for (Repository repository : profile.getRepositories()) {
                 String id = repository.getId();
                 RemoteRepository repo = new RemoteRepository();

--- a/src/test/java/org/apache/maven/resolver/internal/ant/ActiveProfileTest.java
+++ b/src/test/java/org/apache/maven/resolver/internal/ant/ActiveProfileTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.resolver.internal.ant;
+
+import junit.framework.JUnit4TestAdapter;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class ActiveProfileTest extends AntBuildsTest {
+    public static junit.framework.Test suite() {
+        return new JUnit4TestAdapter(ActiveProfileTest.class);
+    }
+
+    @Test
+    public void testActiveProfileNotDefinedInSettingsIsIgnored() {
+        executeTarget("testActiveProfileNotDefinedInSettingsIsIgnored");
+        assertThat(
+                "repository of defined profile not registered",
+                getProject().getReference("defined-repo"),
+                notNullValue());
+    }
+}

--- a/src/test/resources/ant/ActiveProfile/ant.xml
+++ b/src/test/resources/ant/ActiveProfile/ant.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<!DOCTYPE project [
+       <!ENTITY common SYSTEM "../common.xml">
+]>
+
+<project xmlns:repo="antlib:org.apache.maven.resolver.ant">
+
+  &common;
+
+  <target name="setUp">
+  </target>
+
+  <target name="testActiveProfileNotDefinedInSettingsIsIgnored" depends="setUp">
+    <repo:settings file="${project.dir}/settings.xml"/>
+    <repo:pom file="${project.dir}/pom.xml"/>
+  </target>
+
+</project>

--- a/src/test/resources/ant/ActiveProfile/pom.xml
+++ b/src/test/resources/ant/ActiveProfile/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.resolver</groupId>
+  <artifactId>activeprofile-test</artifactId>
+  <version>1.0.0</version>
+</project>

--- a/src/test/resources/ant/ActiveProfile/settings.xml
+++ b/src/test/resources/ant/ActiveProfile/settings.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<settings>
+  <profiles>
+    <profile>
+      <id>defined</id>
+      <repositories>
+        <repository>
+          <id>defined-repo</id>
+          <url>https://repo.maven.apache.org/maven2/</url>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+  <activeProfiles>
+    <activeProfile>defined</activeProfile>
+    <activeProfile>not-defined-anywhere</activeProfile>
+  </activeProfiles>
+</settings>


### PR DESCRIPTION
Fixes #166

## Problem
`AntRepoSys.getRemoteRepositories()` threw a `NullPointerException` when `settings.xml` declared an `activeProfile` that was not defined by any `<profile>` in the file (for example a profile defined only in a POM).

Maven's `DefaultSettingsBuilder` keeps such ids in the effective settings' `activeProfiles` list without validating them, so `settings.getProfilesAsMap().get(profileId)` returns `null` and `profile.getRepositories()` crashed.

## Fix
Log a warning and skip undefined active profiles instead of crashing. Profiles that are defined in `settings.xml` keep working as before.

## Test
New `ActiveProfileTest` reproduces the crash: a `settings.xml` with one defined profile and one `activeProfile` that is not defined anywhere. Before the fix it fails with the NPE above; after the fix the build succeeds, the undefined profile is skipped with a warning, and the defined profile's repository is still registered.

All 54 tests pass (`mvn verify`).