### PR TITLE
Handle pomTarget without a parent directory (#169)

### DIFF
--- a/src/main/java/org/apache/maven/resolver/internal/ant/tasks/CreatePom.java
+++ b/src/main/java/org/apache/maven/resolver/internal/ant/tasks/CreatePom.java
@@ -330,6 +330,9 @@ public class CreatePom extends Task {
      */
     @Override
     public void execute() {
+        if (pomFile.getParentFile() == null) {
+            pomFile = new File(getProject().getBaseDir(), pomFile.getName());
+        }
         if (!pomFile.getParentFile().exists()) {
             pomFile.getParentFile().mkdirs();
         }

--- a/src/test/java/org/apache/maven/resolver/internal/ant/tasks/CreatePomNoParentDirTest.java
+++ b/src/test/java/org/apache/maven/resolver/internal/ant/tasks/CreatePomNoParentDirTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.resolver.internal.ant.tasks;
 
 import java.io.File;
 
+import junit.framework.JUnit4TestAdapter;
 import org.apache.tools.ant.Project;
 import org.junit.Rule;
 import org.junit.Test;
@@ -28,6 +29,9 @@ import org.junit.rules.TemporaryFolder;
 import static org.junit.Assert.assertTrue;
 
 public class CreatePomNoParentDirTest {
+    public static junit.framework.Test suite() {
+        return new JUnit4TestAdapter(CreatePomNoParentDirTest.class);
+    }
 
     @Rule
     public final TemporaryFolder tempFolder = new TemporaryFolder();

--- a/src/test/java/org/apache/maven/resolver/internal/ant/tasks/CreatePomNoParentDirTest.java
+++ b/src/test/java/org/apache/maven/resolver/internal/ant/tasks/CreatePomNoParentDirTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.resolver.internal.ant.tasks;
+
+import java.io.File;
+
+import org.apache.tools.ant.Project;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.junit.Assert.assertTrue;
+
+public class CreatePomNoParentDirTest {
+
+    @Rule
+    public final TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @Test
+    public void testPomTargetWithoutParentDirectory() throws Exception {
+        File baseDir = tempFolder.newFolder("base");
+
+        Project project = new Project();
+        project.setBaseDir(baseDir);
+        project.setProperty("groupId", "g");
+        project.setProperty("artifactId", "a");
+        project.setProperty("version", "1.0");
+
+        CreatePom task = new CreatePom();
+        task.setProject(project);
+        task.setPomTarget("pom.xml");
+        task.setSkipPomRegistration(true);
+
+        task.execute();
+
+        File expected = new File(baseDir, "pom.xml");
+        assertTrue("bare pomTarget should write the POM to the project base dir: " + expected, expected.exists());
+    }
+}


### PR DESCRIPTION
Fixes #169

## Problem
`CreatePom.execute()` threw a `NullPointerException` when `pomTarget` was a bare relative filename such as `pom.xml`.  For such a value `new File("pom.xml").getParentFile()` returns `null`, so the parent-dir check failed.

## Fix
Resolve a bare `pomTarget` against the Ant project base dir before creating the parent directory.  The POM is now written to `${basedir}/pom.xml`, matching the expected behavior of writing to the current working directory / project base dir.  Targets with a directory component (e.g. `out/pom.xml`) behave as before.

## Test
New `CreatePomNoParentDirTest` unit test reproduces the crash: it runs the task with `pomTarget="pom.xml"` and a project base dir, and asserts the POM is written to `${basedir}/pom.xml`.  Before the fix it fails with the NPE above; after the fix it passes.

All 55 tests pass (`mvn verify`).