### PR TITLE
Apply only the active settings.xml proxy (#165)

### DIFF
--- a/src/main/java/org/apache/maven/resolver/internal/ant/AntRepoSys.java
+++ b/src/main/java/org/apache/maven/resolver/internal/ant/AntRepoSys.java
@@ -418,14 +418,15 @@ public class AntRepoSys {
         }
 
         Settings settings = getSettings();
-        for (org.apache.maven.settings.Proxy proxy : settings.getProxies()) {
+        org.apache.maven.settings.Proxy activeProxy = settings.getActiveProxy();
+        if (activeProxy != null) {
             AuthenticationBuilder auth = new AuthenticationBuilder();
-            auth.addUsername(proxy.getUsername()).addPassword(proxy.getPassword());
+            auth.addUsername(activeProxy.getUsername()).addPassword(activeProxy.getPassword());
             selector.add(
                     new org.eclipse.aether.repository.Proxy(
-                            proxy.getProtocol(), proxy.getHost(),
-                            proxy.getPort(), auth.build()),
-                    proxy.getNonProxyHosts());
+                            activeProxy.getProtocol(), activeProxy.getHost(),
+                            activeProxy.getPort(), auth.build()),
+                    activeProxy.getNonProxyHosts());
         }
 
         return selector;

--- a/src/test/java/org/apache/maven/resolver/internal/ant/ProxySelectorTest.java
+++ b/src/test/java/org/apache/maven/resolver/internal/ant/ProxySelectorTest.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.resolver.internal.ant;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import junit.framework.JUnit4TestAdapter;
+import org.apache.tools.ant.Project;
+import org.apache.tools.ant.Task;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.repository.Proxy;
+import org.eclipse.aether.repository.ProxySelector;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class ProxySelectorTest {
+    public static junit.framework.Test suite() {
+        return new JUnit4TestAdapter(ProxySelectorTest.class);
+    }
+
+    @Rule
+    public final TemporaryFolder folder = new TemporaryFolder();
+
+    private Project project;
+
+    private Task task;
+
+    @Before
+    public void setUp() {
+        project = new Project();
+        project.setProperty("user.home", System.getProperty("user.home"));
+        project.setProperty(
+                "maven.repo.local",
+                new File(new File("").getAbsoluteFile(), "target/ant/local-repo").getAbsolutePath());
+
+        task = new Task() {};
+        task.setProject(project);
+    }
+
+    /**
+     * A proxy declared in settings.xml with {@code <active>false</active>} must not be applied to transfers. Only the
+     * active proxy (the first one with {@code isActive() == true}) must be added to the selector.
+     *
+     * @throws Exception in case of problems
+     */
+    @Test
+    public void testInactiveProxyFromSettingsIsNotApplied() throws Exception {
+        File settings = writeSettings(
+                "<proxy>",
+                "  <id>inactive-proxy</id>",
+                "  <active>false</active>",
+                "  <protocol>http</protocol>",
+                "  <host>inactive-proxy.example.com</host>",
+                "  <port>8080</port>",
+                "</proxy>",
+                "<proxy>",
+                "  <id>active-proxy</id>",
+                "  <active>true</active>",
+                "  <protocol>http</protocol>",
+                "  <host>active-proxy.example.com</host>",
+                "  <port>8081</port>",
+                "</proxy>");
+
+        AntRepoSys repoSys = AntRepoSys.getInstance(project);
+        repoSys.setUserSettings(settings);
+
+        try (RepositorySystemSession.CloseableSession session = repoSys.getSession(task, null)) {
+            Proxy proxy = proxyForCentral(session);
+            assertNotNull(proxy);
+            assertEquals("active-proxy.example.com", proxy.getHost());
+            assertEquals(8081, proxy.getPort());
+        }
+    }
+
+    /**
+     * When settings.xml declares only inactive proxies, no proxy may be applied to transfers.
+     *
+     * @throws Exception in case of problems
+     */
+    @Test
+    public void testOnlyInactiveProxiesApplyNoProxy() throws Exception {
+        File settings = writeSettings(
+                "<proxy>",
+                "  <id>inactive-proxy</id>",
+                "  <active>false</active>",
+                "  <protocol>http</protocol>",
+                "  <host>inactive-proxy.example.com</host>",
+                "  <port>8080</port>",
+                "</proxy>");
+
+        AntRepoSys repoSys = AntRepoSys.getInstance(project);
+        repoSys.setUserSettings(settings);
+
+        try (RepositorySystemSession.CloseableSession session = repoSys.getSession(task, null)) {
+            assertNull(proxyForCentral(session));
+        }
+    }
+
+    private Proxy proxyForCentral(RepositorySystemSession session) {
+        ProxySelector selector = session.getProxySelector();
+        RemoteRepository repo =
+                new RemoteRepository.Builder("central", "default", "https://repo.maven.apache.org/maven2/").build();
+        return selector.getProxy(repo);
+    }
+
+    private File writeSettings(String... proxyElements) throws Exception {
+        File file = folder.newFile("settings.xml");
+        StringBuilder content = new StringBuilder();
+        content.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+        content.append("<settings>\n");
+        content.append("  <proxies>\n");
+        for (String element : proxyElements) {
+            content.append("    ").append(element).append('\n');
+        }
+        content.append("  </proxies>\n");
+        content.append("</settings>\n");
+        Files.write(file.toPath(), content.toString().getBytes(StandardCharsets.UTF_8));
+        return file;
+    }
+}


### PR DESCRIPTION
Fixes #165

## Summary

`AntRepoSys.getProxySelector()` added every `<proxy>` entry from `settings.xml` to the aether `DefaultProxySelector` without checking `isActive()`. A proxy the user disabled with `<active>false</active>` therefore still routed all artifact downloads. This matches Maven CLI behavior, which selects the proxy via `settings.getActiveProxy()`.

## Changes

- `AntRepoSys.java`: add only `settings.getActiveProxy()` (the first proxy with `isActive() == true`) to the proxy selector, instead of every proxy in `settings.getProxies()`. No proxy is added when none is active.
- New unit test `ProxySelectorTest` covering:
  - an inactive proxy declared before the active one is not applied (previously the inactive proxy was selected),
  - when only inactive proxies are declared, no proxy is applied.

## Verification

- New tests fail on master (inactive proxy is applied) and pass with the fix.
- `mvn verify` passes: all 56 tests succeed.
