### PR TITLE
Discover global settings from Maven home env vars and properties (#168)

### DIFF
--- a/src/main/java/org/apache/maven/resolver/internal/ant/AetherUtils.java
+++ b/src/main/java/org/apache/maven/resolver/internal/ant/AetherUtils.java
@@ -27,7 +27,18 @@ import org.apache.tools.ant.Project;
 class AetherUtils {
 
     public static File findGlobalSettings(final Project project) {
-        final String mavenHome = getMavenHome(project);
+        return findGlobalSettings(project, System.getenv());
+    }
+
+    /**
+     * Finds the global Maven settings file from the Maven home directory or the Ant home directory, in that order.
+     *
+     * @param project the Ant project to read the {@code ant.home} property from
+     * @param environment the environment variables to consult for the Maven home directory
+     * @return the global settings file, or {@code null} if none exists
+     */
+    static File findGlobalSettings(final Project project, final Map<String, String> environment) {
+        final String mavenHome = getMavenHome(project, environment);
         if (mavenHome != null) {
             final File mavenSettings = new File(new File(mavenHome, "conf"), Names.SETTINGS_XML);
             if (mavenSettings.isFile()) {

--- a/src/main/java/org/apache/maven/resolver/internal/ant/AetherUtils.java
+++ b/src/main/java/org/apache/maven/resolver/internal/ant/AetherUtils.java
@@ -19,6 +19,7 @@
 package org.apache.maven.resolver.internal.ant;
 
 import java.io.File;
+import java.util.Map;
 
 import org.apache.maven.resolver.internal.ant.types.RemoteRepositories;
 import org.apache.tools.ant.Project;
@@ -26,21 +27,47 @@ import org.apache.tools.ant.Project;
 class AetherUtils {
 
     public static File findGlobalSettings(final Project project) {
-        final File file = new File(new File(project.getProperty("ant.home"), "etc"), Names.SETTINGS_XML);
-        if (file.isFile()) {
-            return file;
-        } else {
-            final String mavenHome = getMavenHome(project);
-            if (mavenHome != null) {
-                return new File(new File(mavenHome, "conf"), Names.SETTINGS_XML);
+        final String mavenHome = getMavenHome(project);
+        if (mavenHome != null) {
+            final File mavenSettings = new File(new File(mavenHome, "conf"), Names.SETTINGS_XML);
+            if (mavenSettings.isFile()) {
+                return mavenSettings;
             }
+        }
+
+        final File antSettings = new File(new File(project.getProperty("ant.home"), "etc"), Names.SETTINGS_XML);
+        if (antSettings.isFile()) {
+            return antSettings;
         }
 
         return null;
     }
 
     public static String getMavenHome(final Project project) {
-        return project.getProperty("maven.home");
+        return getMavenHome(project, System.getenv());
+    }
+
+    /**
+     * Resolves the Maven home directory from the {@code maven.home} Ant property, the {@code maven.home} system
+     * property, the {@code MAVEN_HOME} environment variable, or the {@code M2_HOME} environment variable, in that
+     * order.
+     *
+     * @param project the Ant project to read the {@code maven.home} property from
+     * @param environment the environment variables to consult
+     * @return the resolved Maven home directory, or {@code null} if none is set
+     */
+    static String getMavenHome(final Project project, final Map<String, String> environment) {
+        String mavenHome = project.getProperty("maven.home");
+        if (mavenHome == null) {
+            mavenHome = System.getProperty("maven.home");
+        }
+        if (mavenHome == null) {
+            mavenHome = environment.get("MAVEN_HOME");
+        }
+        if (mavenHome == null) {
+            mavenHome = environment.get("M2_HOME");
+        }
+        return mavenHome;
     }
 
     public static File findUserSettings(final Project project) {

--- a/src/test/java/org/apache/maven/resolver/internal/ant/AetherUtilsTest.java
+++ b/src/test/java/org/apache/maven/resolver/internal/ant/AetherUtilsTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.resolver.internal.ant;
 
 import java.io.File;
 import java.nio.file.Files;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -58,6 +59,17 @@ public class AetherUtilsTest {
         Project project = new Project();
         project.setProperty("user.home", System.getProperty("user.home"));
         return project;
+    }
+
+    /**
+     * Looks up the global settings file without consulting the ambient environment, so that the test does not depend
+     * on the {@code MAVEN_HOME}/{@code M2_HOME} variables of the machine the test runs on.
+     *
+     * @param project the Ant project to search for
+     * @return the global settings file, or {@code null} if none exists
+     */
+    private File findGlobalSettings(Project project) {
+        return AetherUtils.findGlobalSettings(project, Collections.emptyMap());
     }
 
     /**
@@ -122,8 +134,7 @@ public class AetherUtilsTest {
                 MAVEN_HOME_PROP, mavenSettings.getParentFile().getParentFile().getAbsolutePath());
 
         assertEquals(
-                mavenSettings.getAbsolutePath(),
-                AetherUtils.findGlobalSettings(project).getAbsolutePath());
+                mavenSettings.getAbsolutePath(), findGlobalSettings(project).getAbsolutePath());
     }
 
     /**
@@ -139,9 +150,7 @@ public class AetherUtilsTest {
         project.setProperty(
                 "ant.home", antSettings.getParentFile().getParentFile().getAbsolutePath());
 
-        assertEquals(
-                antSettings.getAbsolutePath(),
-                AetherUtils.findGlobalSettings(project).getAbsolutePath());
+        assertEquals(antSettings.getAbsolutePath(), findGlobalSettings(project).getAbsolutePath());
     }
 
     /**
@@ -152,7 +161,7 @@ public class AetherUtilsTest {
         Project project = newProject();
         project.setProperty("ant.home", folder.getRoot().getAbsolutePath());
 
-        assertNull(AetherUtils.findGlobalSettings(project));
+        assertNull(findGlobalSettings(project));
     }
 
     private File writeSettings(File home, String dirName) throws Exception {

--- a/src/test/java/org/apache/maven/resolver/internal/ant/AetherUtilsTest.java
+++ b/src/test/java/org/apache/maven/resolver/internal/ant/AetherUtilsTest.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.resolver.internal.ant;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
+
+import junit.framework.JUnit4TestAdapter;
+import org.apache.tools.ant.Project;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class AetherUtilsTest {
+    public static junit.framework.Test suite() {
+        return new JUnit4TestAdapter(AetherUtilsTest.class);
+    }
+
+    private static final String MAVEN_HOME_PROP = "maven.home";
+
+    @Rule
+    public final TemporaryFolder folder = new TemporaryFolder();
+
+    @Before
+    public void setUp() {
+        System.clearProperty(MAVEN_HOME_PROP);
+    }
+
+    @After
+    public void tearDown() {
+        System.clearProperty(MAVEN_HOME_PROP);
+    }
+
+    private Project newProject() {
+        Project project = new Project();
+        project.setProperty("user.home", System.getProperty("user.home"));
+        return project;
+    }
+
+    /**
+     * The {@code maven.home} Ant property must win over the system property and the environment variables.
+     */
+    @Test
+    public void testGetMavenHomePrefersAntProperty() {
+        Project project = newProject();
+        project.setProperty(MAVEN_HOME_PROP, "/ant/maven");
+        System.setProperty(MAVEN_HOME_PROP, "/system/maven");
+
+        assertEquals("/ant/maven", AetherUtils.getMavenHome(project));
+    }
+
+    /**
+     * The {@code maven.home} system property must be used when the Ant property is not set.
+     */
+    @Test
+    public void testGetMavenHomeFallsBackToSystemProperty() {
+        System.setProperty(MAVEN_HOME_PROP, "/system/maven");
+
+        assertEquals("/system/maven", AetherUtils.getMavenHome(newProject()));
+    }
+
+    /**
+     * The {@code MAVEN_HOME} environment variable must win over {@code M2_HOME}.
+     */
+    @Test
+    public void testGetMavenHomeFallsBackToMavenHomeEnv() {
+        Map<String, String> env = new HashMap<>();
+        env.put("MAVEN_HOME", "/env/maven");
+        env.put("M2_HOME", "/env/m2");
+
+        assertEquals("/env/maven", AetherUtils.getMavenHome(newProject(), env));
+    }
+
+    /**
+     * The {@code M2_HOME} environment variable is the last fallback.
+     */
+    @Test
+    public void testGetMavenHomeFallsBackToM2HomeEnv() {
+        Map<String, String> env = new HashMap<>();
+        env.put("M2_HOME", "/env/m2");
+
+        assertEquals("/env/m2", AetherUtils.getMavenHome(newProject(), env));
+    }
+
+    /**
+     * The Maven {@code conf} directory must take precedence over the Ant {@code etc} directory.
+     *
+     * @throws Exception in case of problems
+     */
+    @Test
+    public void testFindGlobalSettingsPrefersMavenConf() throws Exception {
+        File mavenSettings = writeSettings(folder.newFolder("maven-home"), "conf");
+        File antSettings = writeSettings(folder.newFolder("ant-home"), "etc");
+
+        Project project = newProject();
+        project.setProperty(
+                "ant.home", antSettings.getParentFile().getParentFile().getAbsolutePath());
+        project.setProperty(
+                MAVEN_HOME_PROP, mavenSettings.getParentFile().getParentFile().getAbsolutePath());
+
+        assertEquals(
+                mavenSettings.getAbsolutePath(),
+                AetherUtils.findGlobalSettings(project).getAbsolutePath());
+    }
+
+    /**
+     * The Ant {@code etc} directory must be used when no Maven home resolves to an existing settings file.
+     *
+     * @throws Exception in case of problems
+     */
+    @Test
+    public void testFindGlobalSettingsFallsBackToAntEtc() throws Exception {
+        File antSettings = writeSettings(folder.newFolder("ant-home"), "etc");
+
+        Project project = newProject();
+        project.setProperty(
+                "ant.home", antSettings.getParentFile().getParentFile().getAbsolutePath());
+
+        assertEquals(
+                antSettings.getAbsolutePath(),
+                AetherUtils.findGlobalSettings(project).getAbsolutePath());
+    }
+
+    /**
+     * No settings file must be returned when neither location holds one.
+     */
+    @Test
+    public void testFindGlobalSettingsReturnsNullWhenNotFound() {
+        Project project = newProject();
+        project.setProperty("ant.home", folder.getRoot().getAbsolutePath());
+
+        assertNull(AetherUtils.findGlobalSettings(project));
+    }
+
+    private File writeSettings(File home, String dirName) throws Exception {
+        File dir = new File(home, dirName);
+        dir.mkdirs();
+        File settings = new File(dir, Names.SETTINGS_XML);
+        Files.write(settings.toPath(), new byte[0]);
+        return settings;
+    }
+}


### PR DESCRIPTION
Fixes #168

## Summary

`AetherUtils.getMavenHome()` only read the `maven.home` Ant property, which is almost never set in a plain Ant build. Global mirrors, proxies, and server credentials from `settings.xml` were therefore silently ignored. `findGlobalSettings()` also gave `ANT_HOME/etc/settings.xml` precedence over the Maven `conf/settings.xml`, which is likely inverted.

## Changes

- `AetherUtils.getMavenHome()` now resolves the Maven home in order: `maven.home` Ant property, `maven.home` system property, `MAVEN_HOME` environment variable, `M2_HOME` environment variable.
- `AetherUtils.findGlobalSettings()` now prefers the Maven `conf` directory over the Ant `etc` directory, and only returns an existing settings file.
- Added a package-private `getMavenHome(Project, Map)` overload so the environment fallback can be tested deterministically.
- New unit test `AetherUtilsTest` covering:
  - precedence of the `maven.home` Ant property over the system property,
  - fallback to the `maven.home` system property,
  - fallback to `MAVEN_HOME`, then `M2_HOME`,
  - Maven `conf` preferred over Ant `etc`,
  - fallback to Ant `etc` when no Maven settings file exists,
  - `null` when neither location holds a settings file.

## Verification

- New tests fail on master (system property ignored; Ant `etc` wins) and pass with the fix.
- `mvn verify` passes: all 63 tests succeed.
