### PR TITLE
Migrate the example5/example6 tests to JUnit 5 and make them run

### DIFF
--- a/examples/example5/build.xml
+++ b/examples/example5/build.xml
@@ -92,18 +92,24 @@
     <javac
       srcdir='src/test/java'
       destdir='${testBuildDir}'
-      classpathref='testClassPath'
-    />
+      includeantruntime='false'
+    >
+      <classpath>
+        <pathelement location='${mainBuildDir}'/>
+        <path refid='testPath'/>
+      </classpath>
+    </javac>
 
-    <junit printsummary='true' haltonfailure='true'>
+    <junitlauncher printSummary='true' haltOnFailure='true'>
       <classpath>
         <pathelement location='${mainBuildDir}'/>
         <pathelement location='${testBuildDir}'/>
         <path refid='testPath'/>
       </classpath>
-      <formatter type='plain'/>
-      <test name='my.test.TestCase'/>
-    </junit>
+      <test name='test.mygroup.example5.GreetingTest'>
+        <listener type='legacy-plain' sendSysOut='true' outputDir='${targetDir}'/>
+      </test>
+    </junitlauncher>
   </target>
 
   <target name='jar' depends='compile'>
@@ -145,7 +151,7 @@
     <repo:artifact file='${javadocJarFile}' type='jar' classifier='javadocs' id='javadocJar'/>
   </target>
 
-  <target name='install' depends='jar, sourceJar, javadocJar'>
+  <target name='install' depends='test, jar, sourceJar, javadocJar'>
     <echo level='info'>Publishing to local maven repository</echo>
     <repo:artifacts id='localArtifacts'>
       <repo:artifact refid='mainJar'/>

--- a/examples/example5/src/test/java/test/mygroup/example5/GreetingTest.java
+++ b/examples/example5/src/test/java/test/mygroup/example5/GreetingTest.java
@@ -18,17 +18,17 @@
  */
 package test.mygroup.example5;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mygroup.example5.Greeting;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
-public class GreetingTest {
+class GreetingTest {
 
   @Test
-  public void testGreeting() {
+  void greeting() {
     Greeting greeting = new Greeting();
     String greetingResult = greeting.greet(new String[] {"hello", "world"});
-    Assert.assertEquals("{hello,world}!", greetingResult);
+    Assertions.assertEquals("{hello,world}!", greetingResult);
   }
 }

--- a/examples/example6/build.xml
+++ b/examples/example6/build.xml
@@ -68,18 +68,24 @@
     <javac
       srcdir='src/test/java'
       destdir='${testBuildDir}'
-      classpathref='testClassPath'
-    />
+      includeantruntime='false'
+    >
+      <classpath>
+        <pathelement location='${mainBuildDir}'/>
+        <path refid='testPath'/>
+      </classpath>
+    </javac>
 
-    <junit printsummary='true' haltonfailure='true'>
+    <junitlauncher printSummary='true' haltOnFailure='true'>
       <classpath>
         <pathelement location='${mainBuildDir}'/>
         <pathelement location='${testBuildDir}'/>
         <path refid='testPath'/>
       </classpath>
-      <formatter type='plain'/>
-      <test name='my.test.TestCase'/>
-    </junit>
+      <test name='test.mygroup.example6.GreetingTest'>
+        <listener type='legacy-plain' sendSysOut='true' outputDir='${targetDir}'/>
+      </test>
+    </junitlauncher>
   </target>
 
   <target name='jar' depends='compile'>
@@ -121,7 +127,7 @@
     <repo:artifact file='${javadocJarFile}' type='jar' classifier='javadocs' id='javadocJar'/>
   </target>
 
-  <target name='install' depends='jar, sourcesJar, javadocJar'>
+  <target name='install' depends='test, jar, sourcesJar, javadocJar'>
     <echo level='info'>Publishing to local maven repository</echo>
     <repo:artifacts id='localArtifacts'>
       <repo:artifact refid='mainJar'/>

--- a/examples/example6/src/test/java/test/mygroup/example6/GreetingTest.java
+++ b/examples/example6/src/test/java/test/mygroup/example6/GreetingTest.java
@@ -16,19 +16,19 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package test.mygroup.example5;
+package test.mygroup.example6;
 
-import org.junit.Test;
-import org.mygroup.example5.Greeting;
+import org.junit.jupiter.api.Test;
+import org.mygroup.example6.Greeting;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
-public class GreetingTest {
+class GreetingTest {
 
   @Test
-  public void testGreeting() {
+  void greeting() {
     Greeting greeting = new Greeting();
     String greetingResult = greeting.greet(new String[] {"hello", "world"});
-    Assert.assertEquals("{hello, world}!", greetingResult);
+    Assertions.assertEquals("{hello,world}!", greetingResult);
   }
 }


### PR DESCRIPTION
Follow-up to #179, targeting its branch.

#179 drops `ant-junit` and `junit:junit` from the `maven-antrun-plugin` classpath that `run-ant-examples` uses, but `examples/example5/build.xml` and `examples/example6/build.xml` still invoke the JUnit 4 `<junit>` Ant task. It does not break today only because `installAndClean` never reaches the `test` target and Ant resolves task names lazily — but the task can no longer be created on that classpath.

Restoring `ant-junit` would be the wrong direction: **both examples already declare JUnit 5** (`junit-bom` 5.12.2 with `junit-jupiter-engine` and `junit-platform-launcher`, in `examples/example5/build.xml` and `examples/example6/pom.xml`). Only the Ant task and the test sources were left behind.

### Those test targets had never run

`ant test` in example5 fails on unmodified `master`, before it ever reaches `<junit>`:

```
BUILD FAILED
examples/example5/build.xml:96: Reference testClassPath not found.
```

Pre-existing problems found in the process, all now fixed:

- `classpathref='testClassPath'` names a reference that is never defined — `repo:resolve` creates `testPath`.
- `<test name='my.test.TestCase'/>` names a class that does not exist; the actual test is `GreetingTest`.
- The JUnit 4 test sources cannot compile against the JUnit 5-only test classpath.
- example6's test was copy-pasted from example5: it declared `package test.mygroup.example5` and imported `org.mygroup.example5.Greeting`, while example6's class is `org.mygroup.example6.Greeting`.
- example6's test asserted `"{hello, world}!"` where `ArrayUtils.toString` produces `"{hello,world}!"`.

### Changes

- `<junit>` → `<junitlauncher>` in both build files, with a `legacy-plain` listener writing to `${targetDir}` (a bare listener drops `TEST-*.txt` in the example root and trips the `apache-rat` license check).
- Compile the tests against a nested `<classpath>` of `${mainBuildDir}` + `testPath`, with `includeantruntime='false'`.
- Point `<test name>` at the class that exists; move example6's test to `test/mygroup/example6/` with the correct import and expected string.
- Convert both tests to `org.junit.jupiter.api`.
- Add `test` to each `install` target's `depends`, so `run-ant-examples` actually exercises it — otherwise these targets silently rot again.

No `pom.xml` change is needed: `ant-junitlauncher` as the sole antrun dependency is correct once the examples use `<junitlauncher>`.

### Verification

- `ant clean test` in example5 and example6 standalone: `Tests run: 1, Failures: 0` each.
- `mvn -o -Prun-its -DskipTests verify`: BUILD SUCCESS — the 17 main test classes plus both example tests run under the antrun plugin's classpath, which carries only `ant-junitlauncher`. That is the meaningful check, since standalone `ant` ships `ant-junit.jar` in its lib and would mask the problem.
- `apache-rat` check passes; no stray report files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
