### PR TITLE
Derive POM dependencies the way Maven does, and test it against dependency:list

### DIFF
--- a/src/main/java/org/apache/maven/resolver/internal/ant/AntRepoSys.java
+++ b/src/main/java/org/apache/maven/resolver/internal/ant/AntRepoSys.java
@@ -95,6 +95,7 @@ import org.eclipse.aether.installation.InstallationException;
 import org.eclipse.aether.repository.AuthenticationSelector;
 import org.eclipse.aether.repository.MirrorSelector;
 import org.eclipse.aether.repository.ProxySelector;
+import org.eclipse.aether.resolution.ArtifactDescriptorResult;
 import org.eclipse.aether.supplier.RepositorySystemSupplier;
 import org.eclipse.aether.supplier.SessionBuilderSupplier;
 import org.eclipse.aether.util.repository.AuthenticationBuilder;
@@ -752,6 +753,13 @@ public class AntRepoSys {
             }
 
             if (dependencies != null) {
+                if (dependencies.getPom() != null) {
+                    // Maven collects for the project artifact; without a root the project cannot be told apart
+                    // from its own dependencies when it shows up in its graph.
+                    Model model = dependencies.getPom().getModel(task);
+                    collectRequest.setRootArtifact(
+                            new DefaultArtifact(model.getGroupId(), model.getArtifactId(), "pom", model.getVersion()));
+                }
                 populateCollectRequest(collectRequest, task, session, dependencies, Collections.emptyList());
             }
 
@@ -782,7 +790,7 @@ public class AntRepoSys {
         for (DependencyContainer container : dependencies.getDependencyContainers()) {
             if (container instanceof Dependency) {
                 Dependency dep = (Dependency) container;
-                ids.add(dep.getVersionlessKey());
+                ids.add(ConverterUtils.versionlessKey(dep, session));
                 collectRequest.addDependency(ConverterUtils.toDependency(dep, globalExclusions, session));
             } else {
                 populateCollectRequest(collectRequest, task, session, (Dependencies) container, globalExclusions);
@@ -791,69 +799,37 @@ public class AntRepoSys {
 
         if (dependencies.getPom() != null) {
             Model model = dependencies.getPom().getModel(task);
-            if (model.getDependencyManagement() != null) {
-                for (org.apache.maven.model.Dependency manDep :
-                        model.getDependencyManagement().getDependencies()) {
-                    Dependency dependency = new Dependency();
-                    dependency.setArtifactId(manDep.getArtifactId());
-                    dependency.setClassifier(manDep.getClassifier());
-                    dependency.setGroupId(manDep.getGroupId());
-                    dependency.setScope(manDep.getScope());
-                    dependency.setType(manDep.getType());
-                    dependency.setVersion(manDep.getVersion());
-                    if (manDep.getSystemPath() != null
-                            && !manDep.getSystemPath().isEmpty()) {
-                        dependency.setSystemPath(task.getProject().resolveFile(manDep.getSystemPath()));
-                    }
-                    for (org.apache.maven.model.Exclusion exc : manDep.getExclusions()) {
-                        Exclusion exclusion = new Exclusion();
-                        exclusion.setGroupId(exc.getGroupId());
-                        exclusion.setArtifactId(exc.getArtifactId());
-                        exclusion.setClassifier("*");
-                        exclusion.setExtension("*");
-                        dependency.addExclusion(exclusion);
-                    }
-                    collectRequest.addManagedDependency(
-                            ConverterUtils.toManagedDependency(dependency, globalExclusions, session));
-                }
+            ArtifactDescriptorResult descriptor = ConverterUtils.toArtifactDescriptor(session, model);
+
+            if (!descriptor.getRepositories().isEmpty()) {
+                collectRequest.setRepositories(getRemoteRepoMan()
+                        .aggregateRepositories(
+                                session, collectRequest.getRepositories(), descriptor.getRepositories(), true));
             }
 
-            for (org.apache.maven.model.Dependency dep : model.getDependencies()) {
-                Dependency dependency = new Dependency();
-                dependency.setArtifactId(dep.getArtifactId());
-                dependency.setClassifier(dep.getClassifier());
-                dependency.setGroupId(dep.getGroupId());
-                dependency.setScope(dep.getScope());
-                dependency.setType(dep.getType());
-                dependency.setVersion(dep.getVersion());
-                if (ids.contains(dependency.getVersionlessKey())) {
+            for (org.eclipse.aether.graph.Dependency managedDependency : descriptor.getManagedDependencies()) {
+                collectRequest.addManagedDependency(ConverterUtils.addExclusions(managedDependency, globalExclusions));
+            }
+
+            for (org.eclipse.aether.graph.Dependency dependency : descriptor.getDependencies()) {
+                String key = ConverterUtils.versionlessKey(dependency.getArtifact());
+                if (ids.contains(key)) {
                     project.log(
-                            "Ignoring dependency " + dependency.getVersionlessKey() + " from " + model.getId()
-                                    + ", already declared locally",
+                            "Ignoring dependency " + key + " from " + model.getId() + ", already declared locally",
                             Project.MSG_VERBOSE);
                     continue;
                 }
-                if (dep.getSystemPath() != null && !dep.getSystemPath().isEmpty()) {
-                    dependency.setSystemPath(task.getProject().resolveFile(dep.getSystemPath()));
-                }
-                for (org.apache.maven.model.Exclusion exc : dep.getExclusions()) {
-                    Exclusion exclusion = new Exclusion();
-                    exclusion.setGroupId(exc.getGroupId());
-                    exclusion.setArtifactId(exc.getArtifactId());
-                    exclusion.setClassifier("*");
-                    exclusion.setExtension("*");
-                    dependency.addExclusion(exclusion);
-                }
-                collectRequest.addDependency(ConverterUtils.toDependency(dependency, globalExclusions, session));
+                collectRequest.addDependency(ConverterUtils.addExclusions(dependency, globalExclusions));
             }
         }
 
         if (dependencies.getFile() != null) {
             List<Dependency> deps = readDependencies(dependencies.getFile());
             for (Dependency dependency : deps) {
-                if (ids.contains(dependency.getVersionlessKey())) {
+                String key = ConverterUtils.versionlessKey(dependency, session);
+                if (ids.contains(key)) {
                     project.log(
-                            "Ignoring dependency " + dependency.getVersionlessKey() + " from " + dependencies.getFile()
+                            "Ignoring dependency " + key + " from " + dependencies.getFile()
                                     + ", already declared locally",
                             Project.MSG_VERBOSE);
                     continue;

--- a/src/main/java/org/apache/maven/resolver/internal/ant/ConverterUtils.java
+++ b/src/main/java/org/apache/maven/resolver/internal/ant/ConverterUtils.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import org.apache.maven.model.Model;
+import org.apache.maven.repository.internal.ArtifactDescriptorReaderDelegate;
 import org.apache.maven.resolver.internal.ant.types.Authentication;
 import org.apache.maven.resolver.internal.ant.types.Dependency;
 import org.apache.maven.resolver.internal.ant.types.Exclusion;
@@ -41,6 +43,8 @@ import org.eclipse.aether.artifact.ArtifactTypeRegistry;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.artifact.DefaultArtifactType;
 import org.eclipse.aether.repository.RepositoryPolicy;
+import org.eclipse.aether.resolution.ArtifactDescriptorRequest;
+import org.eclipse.aether.resolution.ArtifactDescriptorResult;
 import org.eclipse.aether.util.repository.AuthenticationBuilder;
 
 /**
@@ -48,7 +52,7 @@ import org.eclipse.aether.util.repository.AuthenticationBuilder;
  */
 class ConverterUtils {
 
-    private static org.eclipse.aether.artifact.Artifact toArtifact(Dependency dependency, ArtifactTypeRegistry types) {
+    static org.eclipse.aether.artifact.Artifact toArtifact(Dependency dependency, ArtifactTypeRegistry types) {
         ArtifactType type = types.get(dependency.getType());
         if (type == null) {
             type = new DefaultArtifactType(dependency.getType());
@@ -70,6 +74,78 @@ class ConverterUtils {
                 type);
     }
 
+    /**
+     * Converts a Maven {@link Model} into the artifact descriptor that Maven itself would derive from it.
+     * <p>
+     * The conversion is delegated to Maven's own {@link ArtifactDescriptorReaderDelegate}, the code that turns a
+     * model into resolver input during a Maven build, so that a POM contributes the same dependencies, managed
+     * dependencies and repositories here as it does there.
+     *
+     * @param session the repository system session supplying the artifact type registry
+     * @param model the effective model to convert
+     * @return the artifact descriptor derived from the model
+     */
+    public static ArtifactDescriptorResult toArtifactDescriptor(RepositorySystemSession session, Model model) {
+        org.eclipse.aether.artifact.Artifact pomArtifact =
+                new DefaultArtifact(model.getGroupId(), model.getArtifactId(), "pom", model.getVersion());
+        ArtifactDescriptorRequest request = new ArtifactDescriptorRequest();
+        request.setArtifact(pomArtifact);
+        ArtifactDescriptorResult result = new ArtifactDescriptorResult(request);
+        new ArtifactDescriptorReaderDelegate().populateResult(session, result, model);
+        return result;
+    }
+
+    /**
+     * Returns the {@code groupId:artifactId:extension[:classifier]} key of an artifact, used to detect that a POM
+     * dependency is already declared locally.
+     *
+     * @param artifact the artifact to key
+     * @return the versionless key of the artifact
+     */
+    public static String versionlessKey(org.eclipse.aether.artifact.Artifact artifact) {
+        StringBuilder key = new StringBuilder(128);
+        key.append(artifact.getGroupId())
+                .append(':')
+                .append(artifact.getArtifactId())
+                .append(':')
+                .append(artifact.getExtension());
+        if (!artifact.getClassifier().isEmpty()) {
+            key.append(':').append(artifact.getClassifier());
+        }
+        return key.toString();
+    }
+
+    /**
+     * Returns the versionless key of an Ant {@code <dependency>}, normalized the same way as
+     * {@link #versionlessKey(org.eclipse.aether.artifact.Artifact)} so that both can be compared.
+     *
+     * @param dependency the Ant dependency to key
+     * @param session the repository system session supplying the artifact type registry
+     * @return the versionless key of the dependency
+     */
+    public static String versionlessKey(Dependency dependency, RepositorySystemSession session) {
+        return versionlessKey(toArtifact(dependency, session.getArtifactTypeRegistry()));
+    }
+
+    /**
+     * Returns a copy of the dependency with the given exclusions added to the ones it already carries.
+     *
+     * @param dependency the dependency to extend
+     * @param exclusions the exclusions to add, may be empty
+     * @return the dependency with the merged exclusions
+     */
+    public static org.eclipse.aether.graph.Dependency addExclusions(
+            org.eclipse.aether.graph.Dependency dependency, Collection<Exclusion> exclusions) {
+        if (exclusions == null || exclusions.isEmpty()) {
+            return dependency;
+        }
+        Collection<org.eclipse.aether.graph.Exclusion> merged = new LinkedHashSet<>(dependency.getExclusions());
+        for (Exclusion exclusion : exclusions) {
+            merged.add(toExclusion(exclusion));
+        }
+        return dependency.setExclusions(merged);
+    }
+
     public static org.eclipse.aether.repository.Authentication toAuthentication(Authentication auth) {
         if (auth == null) {
             return null;
@@ -86,15 +162,6 @@ class ConverterUtils {
         return new org.eclipse.aether.graph.Dependency(
                 toArtifact(dependency, session.getArtifactTypeRegistry()),
                 scope == null || scope.trim().isEmpty() ? "compile" : scope,
-                false,
-                toExclusions(dependency.getExclusions(), exclusions));
-    }
-
-    public static org.eclipse.aether.graph.Dependency toManagedDependency(
-            Dependency dependency, List<Exclusion> exclusions, RepositorySystemSession session) {
-        return new org.eclipse.aether.graph.Dependency(
-                toArtifact(dependency, session.getArtifactTypeRegistry()),
-                dependency.getScope(),
                 false,
                 toExclusions(dependency.getExclusions(), exclusions));
     }

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -169,6 +169,12 @@ Dependencies are used to to create classpaths or filesets. They are used by
 the `<resolve>`-task, which collects the artifacts belonging to the dependencies
 transitively.
 
+A `<dependencies>` element that names a POM contributes the dependencies, the dependency management
+and the repositories of that POM, the same way the POM would contribute them to a Maven build. The
+repositories configured on the Ant side take precedence over the ones the POM declares, and a POM
+carries Maven Central through the super POM even when it declares no repository of its own. Mirrors
+and offline mode in `settings.xml` apply to all of them.
+
 ```xml
 <dependency coords="g:a:v:scope"/>
 

--- a/src/test/java/org/apache/maven/resolver/internal/ant/ConverterUtilsTest.java
+++ b/src/test/java/org/apache/maven/resolver/internal/ant/ConverterUtilsTest.java
@@ -1,0 +1,248 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.resolver.internal.ant;
+
+import java.io.File;
+
+import junit.framework.JUnit4TestAdapter;
+import org.apache.maven.model.DependencyManagement;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Repository;
+import org.apache.tools.ant.Project;
+import org.apache.tools.ant.Task;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.graph.Exclusion;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.ArtifactDescriptorResult;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Checks that a POM contributes to resolution the same way it does under Maven, which is what
+ * {@link ConverterUtils#toArtifactDescriptor} delegates to Maven's own code for.
+ */
+public class ConverterUtilsTest {
+    public static junit.framework.Test suite() {
+        return new JUnit4TestAdapter(ConverterUtilsTest.class);
+    }
+
+    private Project project;
+
+    private Task task;
+
+    @Before
+    public void setUp() {
+        project = new Project();
+        project.setProperty("user.home", System.getProperty("user.home"));
+        project.setProperty(
+                "maven.repo.local",
+                new File(new File("").getAbsoluteFile(), "target/ant/local-repo").getAbsolutePath());
+
+        task = new Task() {};
+        task.setProject(project);
+    }
+
+    private RepositorySystemSession.CloseableSession newSession() {
+        return AntRepoSys.getInstance(project).getSession(task, null);
+    }
+
+    private static Model newModel() {
+        Model model = new Model();
+        model.setModelVersion("4.0.0");
+        model.setGroupId("test");
+        model.setArtifactId("project");
+        model.setVersion("1.0");
+        model.setPackaging("jar");
+        return model;
+    }
+
+    private static org.apache.maven.model.Dependency newDependency(String artifactId) {
+        org.apache.maven.model.Dependency dependency = new org.apache.maven.model.Dependency();
+        dependency.setGroupId("test");
+        dependency.setArtifactId(artifactId);
+        dependency.setVersion("1.0");
+        dependency.setType("jar");
+        dependency.setScope("compile");
+        return dependency;
+    }
+
+    private static ArtifactDescriptorResult descriptorOf(RepositorySystemSession session, Model model) {
+        return ConverterUtils.toArtifactDescriptor(session, model);
+    }
+
+    @Test
+    public void testDescriptorArtifactIsThePomOfTheModel() {
+        Model model = newModel();
+
+        try (RepositorySystemSession.CloseableSession session = newSession()) {
+            ArtifactDescriptorResult descriptor = descriptorOf(session, model);
+
+            assertEquals("test", descriptor.getArtifact().getGroupId());
+            assertEquals("project", descriptor.getArtifact().getArtifactId());
+            assertEquals("pom", descriptor.getArtifact().getExtension());
+            assertEquals("1.0", descriptor.getArtifact().getVersion());
+        }
+    }
+
+    @Test
+    public void testOptionalIsCarriedFromTheModel() {
+        Model model = newModel();
+        org.apache.maven.model.Dependency optional = newDependency("optional-dep");
+        optional.setOptional("true");
+        model.addDependency(optional);
+        model.addDependency(newDependency("plain-dep"));
+
+        try (RepositorySystemSession.CloseableSession session = newSession()) {
+            ArtifactDescriptorResult descriptor = descriptorOf(session, model);
+
+            assertEquals(Boolean.TRUE, descriptor.getDependencies().get(0).getOptional());
+            assertNull(
+                    "a dependency without <optional> must stay unset so that it can still be managed",
+                    descriptor.getDependencies().get(1).getOptional());
+        }
+    }
+
+    @Test
+    public void testOptionalIsCarriedFromDependencyManagement() {
+        Model model = newModel();
+        org.apache.maven.model.Dependency managed = newDependency("managed-dep");
+        managed.setOptional("true");
+        DependencyManagement dependencyManagement = new DependencyManagement();
+        dependencyManagement.addDependency(managed);
+        model.setDependencyManagement(dependencyManagement);
+
+        try (RepositorySystemSession.CloseableSession session = newSession()) {
+            ArtifactDescriptorResult descriptor = descriptorOf(session, model);
+
+            assertEquals(
+                    Boolean.TRUE, descriptor.getManagedDependencies().get(0).getOptional());
+        }
+    }
+
+    @Test
+    public void testTypeIsMappedThroughTheArtifactTypeRegistry() {
+        Model model = newModel();
+        org.apache.maven.model.Dependency testJar = newDependency("test-jar-dep");
+        testJar.setType("test-jar");
+        model.addDependency(testJar);
+
+        try (RepositorySystemSession.CloseableSession session = newSession()) {
+            Dependency dependency =
+                    descriptorOf(session, model).getDependencies().get(0);
+
+            assertEquals("jar", dependency.getArtifact().getExtension());
+            assertEquals("tests", dependency.getArtifact().getClassifier());
+            assertEquals("compile", dependency.getScope());
+        }
+    }
+
+    @Test
+    public void testExclusionsAreCarriedAsWildcards() {
+        Model model = newModel();
+        org.apache.maven.model.Dependency dependency = newDependency("excluding-dep");
+        org.apache.maven.model.Exclusion exclusion = new org.apache.maven.model.Exclusion();
+        exclusion.setGroupId("excluded");
+        exclusion.setArtifactId("artifact");
+        dependency.addExclusion(exclusion);
+        model.addDependency(dependency);
+
+        try (RepositorySystemSession.CloseableSession session = newSession()) {
+            Exclusion converted = descriptorOf(session, model)
+                    .getDependencies()
+                    .get(0)
+                    .getExclusions()
+                    .iterator()
+                    .next();
+
+            assertEquals("excluded", converted.getGroupId());
+            assertEquals("artifact", converted.getArtifactId());
+            assertEquals("*", converted.getClassifier());
+            assertEquals("*", converted.getExtension());
+        }
+    }
+
+    @Test
+    public void testRepositoriesAreCarriedFromTheModel() {
+        Model model = newModel();
+        Repository repository = new Repository();
+        repository.setId("example");
+        repository.setUrl("https://example.invalid/repo");
+        model.addRepository(repository);
+
+        try (RepositorySystemSession.CloseableSession session = newSession()) {
+            RemoteRepository converted =
+                    descriptorOf(session, model).getRepositories().get(0);
+
+            assertEquals("example", converted.getId());
+            assertEquals("https://example.invalid/repo", converted.getUrl());
+        }
+    }
+
+    @Test
+    public void testVersionlessKeyNormalizesTypeAndClassifier() {
+        Model model = newModel();
+        org.apache.maven.model.Dependency testJar = newDependency("test-jar-dep");
+        testJar.setType("test-jar");
+        model.addDependency(testJar);
+        model.addDependency(newDependency("plain-dep"));
+
+        try (RepositorySystemSession.CloseableSession session = newSession()) {
+            ArtifactDescriptorResult descriptor = descriptorOf(session, model);
+
+            assertEquals(
+                    "test:test-jar-dep:jar:tests",
+                    ConverterUtils.versionlessKey(
+                            descriptor.getDependencies().get(0).getArtifact()));
+            assertEquals(
+                    "test:plain-dep:jar",
+                    ConverterUtils.versionlessKey(
+                            descriptor.getDependencies().get(1).getArtifact()));
+        }
+    }
+
+    @Test
+    public void testVersionlessKeyOfAntDependencyMatchesTheModelKey() {
+        Model model = newModel();
+        org.apache.maven.model.Dependency testJar = newDependency("test-jar-dep");
+        testJar.setType("test-jar");
+        model.addDependency(testJar);
+
+        org.apache.maven.resolver.internal.ant.types.Dependency antDependency =
+                new org.apache.maven.resolver.internal.ant.types.Dependency();
+        antDependency.setGroupId("test");
+        antDependency.setArtifactId("test-jar-dep");
+        antDependency.setVersion("1.0");
+        antDependency.setType("test-jar");
+
+        try (RepositorySystemSession.CloseableSession session = newSession()) {
+            ArtifactDescriptorResult descriptor = descriptorOf(session, model);
+
+            assertTrue(
+                    "an Ant <dependency> must key the same as the POM dependency it overrides",
+                    ConverterUtils.versionlessKey(antDependency, session)
+                            .equals(ConverterUtils.versionlessKey(
+                                    descriptor.getDependencies().get(0).getArtifact())));
+        }
+    }
+}

--- a/src/test/java/org/apache/maven/resolver/internal/ant/MavenParityTest.java
+++ b/src/test/java/org/apache/maven/resolver/internal/ant/MavenParityTest.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.resolver.internal.ant;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TreeSet;
+
+import junit.framework.JUnit4TestAdapter;
+import org.apache.maven.resolver.internal.ant.types.Dependencies;
+import org.apache.maven.resolver.internal.ant.types.Pom;
+import org.apache.maven.resolver.internal.ant.types.RemoteRepositories;
+import org.apache.maven.resolver.internal.ant.types.RemoteRepository;
+import org.apache.tools.ant.Project;
+import org.apache.tools.ant.Task;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.collection.CollectResult;
+import org.eclipse.aether.graph.DependencyFilter;
+import org.eclipse.aether.graph.DependencyNode;
+import org.eclipse.aether.util.filter.DependencyFilterUtils;
+import org.eclipse.aether.util.graph.visitor.NodeListGenerator;
+import org.eclipse.aether.util.graph.visitor.PreorderDependencyNodeConsumerVisitor;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Resolves a POM through the Ant tasks and compares the outcome with what {@code mvn dependency:list}
+ * reports for the same POM, per classpath scope.
+ * <p>
+ * The expectations next to the fixture POM are recorded Maven output, not hand-written; their headers carry
+ * the Maven version they came from and the command that re-records them. A difference here is a difference
+ * between the two tools, which is the thing worth failing a build over.
+ */
+public class MavenParityTest {
+    public static junit.framework.Test suite() {
+        return new JUnit4TestAdapter(MavenParityTest.class);
+    }
+
+    private static final File FIXTURE_DIR =
+            new File(new File("").getAbsoluteFile(), "src/test/resources/ant/MavenParity");
+
+    private Project project;
+
+    private Task task;
+
+    @Before
+    public void setUp() {
+        project = new Project();
+        project.setProperty("user.home", System.getProperty("user.home"));
+        project.setProperty(
+                "maven.repo.local",
+                new File(new File("").getAbsoluteFile(), "target/ant/local-repo").getAbsolutePath());
+
+        task = new Task() {};
+        task.setProject(project);
+    }
+
+    @Test
+    public void testCompileClasspathMatchesMaven() throws IOException {
+        assertParity("compile");
+    }
+
+    @Test
+    public void testRuntimeClasspathMatchesMaven() throws IOException {
+        assertParity("runtime");
+    }
+
+    @Test
+    public void testTestClasspathMatchesMaven() throws IOException {
+        assertParity("test");
+    }
+
+    private void assertParity(String classpath) throws IOException {
+        List<String> expected = readExpectation(classpath);
+        List<String> actual = resolve(classpath);
+
+        assertEquals(
+                "the Ant tasks and Maven disagree about the " + classpath + " classpath of "
+                        + new File(FIXTURE_DIR, "pom.xml"),
+                String.join("\n", expected),
+                String.join("\n", actual));
+    }
+
+    private List<String> readExpectation(String classpath) throws IOException {
+        List<String> lines = new ArrayList<>();
+        for (String line : Files.readAllLines(
+                new File(FIXTURE_DIR, "expected-" + classpath + ".txt").toPath(), StandardCharsets.UTF_8)) {
+            line = line.trim();
+            if (!line.isEmpty() && !line.startsWith("#")) {
+                lines.add(line);
+            }
+        }
+        return lines;
+    }
+
+    private List<String> resolve(String classpath) {
+        Pom pom = new Pom();
+        pom.setProject(project);
+        pom.setFile(new File(FIXTURE_DIR, "pom.xml"));
+
+        Dependencies dependencies = new Dependencies();
+        dependencies.setProject(project);
+        dependencies.addPom(pom);
+
+        CollectResult result =
+                AntRepoSys.getInstance(project).collectDependencies(task, dependencies, null, centralOnly());
+
+        DependencyFilter filter = DependencyFilterUtils.classpathFilter(classpath);
+        NodeListGenerator generator = new NodeListGenerator();
+        result.getRoot().accept(new PreorderDependencyNodeConsumerVisitor(generator, filter));
+
+        // a sorted set: dependency:list reports each artifact once, in no order this test should depend on
+        TreeSet<String> coordinates = new TreeSet<>();
+        for (DependencyNode node : generator.getNodesWithDependencies()) {
+            coordinates.add(coordinates(node));
+        }
+        return new ArrayList<>(coordinates);
+    }
+
+    private static String coordinates(DependencyNode node) {
+        Artifact artifact = node.getArtifact();
+        StringBuilder buffer = new StringBuilder(128);
+        buffer.append(artifact.getGroupId())
+                .append(':')
+                .append(artifact.getArtifactId())
+                .append(':')
+                .append(artifact.getExtension());
+        if (!artifact.getClassifier().isEmpty()) {
+            buffer.append(':').append(artifact.getClassifier());
+        }
+        buffer.append(':')
+                .append(artifact.getVersion())
+                .append(':')
+                .append(node.getDependency().getScope());
+        return buffer.toString();
+    }
+
+    private RemoteRepositories centralOnly() {
+        RemoteRepository central = new RemoteRepository();
+        central.setProject(project);
+        central.setId("central");
+        central.setUrl("https://repo.maven.apache.org/maven2/");
+        central.setReleases(true);
+        central.setSnapshots(false);
+
+        RemoteRepositories repositories = new RemoteRepositories();
+        repositories.setProject(project);
+        repositories.addRemoterepo(central);
+        return repositories;
+    }
+}

--- a/src/test/java/org/apache/maven/resolver/internal/ant/PomRepositoriesTest.java
+++ b/src/test/java/org/apache/maven/resolver/internal/ant/PomRepositoriesTest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.resolver.internal.ant;
+
+import java.io.File;
+import java.util.List;
+
+import junit.framework.JUnit4TestAdapter;
+import org.apache.maven.resolver.internal.ant.types.Dependencies;
+import org.apache.maven.resolver.internal.ant.types.Pom;
+import org.apache.maven.resolver.internal.ant.types.RemoteRepositories;
+import org.apache.maven.resolver.internal.ant.types.RemoteRepository;
+import org.apache.tools.ant.Project;
+import org.apache.tools.ant.Task;
+import org.eclipse.aether.collection.CollectResult;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Checks that the repositories a POM declares end up in the collect request, behind the ones configured
+ * on the Ant side.
+ */
+public class PomRepositoriesTest {
+    public static junit.framework.Test suite() {
+        return new JUnit4TestAdapter(PomRepositoriesTest.class);
+    }
+
+    private static final File FIXTURE_DIR =
+            new File(new File("").getAbsoluteFile(), "src/test/resources/ant/PomRepositories");
+
+    private static final String ANT_SIDE_URL = "https://example.invalid/ant";
+
+    private static final String POM_SIDE_URL = "https://example.invalid/repo";
+
+    private static final String SUPER_POM_URL = "https://repo.maven.apache.org/maven2";
+
+    private Project project;
+
+    private Task task;
+
+    @Before
+    public void setUp() {
+        project = new Project();
+        project.setProperty("user.home", System.getProperty("user.home"));
+        project.setProperty(
+                "maven.repo.local",
+                new File(new File("").getAbsoluteFile(), "target/ant/local-repo").getAbsolutePath());
+
+        task = new Task() {};
+        task.setProject(project);
+
+        // an empty settings.xml: a mirror in the developer's own would rewrite what this test asserts on
+        File settings = new File(FIXTURE_DIR, "settings.xml");
+        AntRepoSys.getInstance(project).setUserSettings(settings);
+        AntRepoSys.getInstance(project).setGlobalSettings(settings);
+    }
+
+    @Test
+    public void testPomRepositoriesAreCollectedAgainstBehindTheConfiguredOnes() {
+        Pom pom = new Pom();
+        pom.setProject(project);
+        pom.setFile(new File(FIXTURE_DIR, "pom.xml"));
+
+        Dependencies dependencies = new Dependencies();
+        dependencies.setProject(project);
+        dependencies.addPom(pom);
+
+        CollectResult result =
+                AntRepoSys.getInstance(project).collectDependencies(task, dependencies, null, antSideRepository());
+
+        List<org.eclipse.aether.repository.RemoteRepository> repositories =
+                result.getRequest().getRepositories();
+
+        assertEquals(
+                "expected the Ant repository, the POM repository and the one the super POM adds, got " + repositories,
+                3,
+                repositories.size());
+        assertEquals(
+                "the repositories configured on the Ant side must stay dominant",
+                ANT_SIDE_URL,
+                repositories.get(0).getUrl());
+        assertEquals(POM_SIDE_URL, repositories.get(1).getUrl());
+        assertEquals(
+                "a POM carries Maven Central through the super POM, as it does under Maven",
+                SUPER_POM_URL,
+                repositories.get(2).getUrl());
+    }
+
+    private RemoteRepositories antSideRepository() {
+        RemoteRepository antSide = new RemoteRepository();
+        antSide.setProject(project);
+        antSide.setId("from-the-ant-build");
+        antSide.setUrl(ANT_SIDE_URL);
+
+        RemoteRepositories repositories = new RemoteRepositories();
+        repositories.setProject(project);
+        repositories.addRemoterepo(antSide);
+        return repositories;
+    }
+}

--- a/src/test/resources/ant/MavenParity/expected-compile.txt
+++ b/src/test/resources/ant/MavenParity/expected-compile.txt
@@ -1,0 +1,15 @@
+# What "mvn dependency:list -DincludeScope=compile" reports for the pom.xml next to this file.
+#
+# Recorded with Apache Maven 3.10.0-rc-1 and maven-dependency-plugin 3.9.0. To re-record:
+#
+#   mvn org.apache.maven.plugins:maven-dependency-plugin:3.9.0:list \
+#       -DincludeScope=compile -DoutputFile=/tmp/compile.txt
+#   sed -e '1d' -e 's/ -- .*//' -e 's/ (optional)//' -e 's/^ *//' /tmp/compile.txt | grep -v '^$' | sort
+#
+# groupId:artifactId:type[:classifier]:version:scope
+com.google.code.findbugs:jsr305:jar:3.0.2:compile
+commons-codec:commons-codec:jar:1.11:compile
+jakarta.servlet:jakarta.servlet-api:jar:6.1.0:provided
+org.apache.commons:commons-lang3:jar:3.20.0:compile
+org.apache.httpcomponents:httpclient:jar:4.5.14:compile
+org.apache.httpcomponents:httpcore:jar:4.4.16:compile

--- a/src/test/resources/ant/MavenParity/expected-runtime.txt
+++ b/src/test/resources/ant/MavenParity/expected-runtime.txt
@@ -1,0 +1,16 @@
+# What "mvn dependency:list -DincludeScope=runtime" reports for the pom.xml next to this file.
+#
+# Recorded with Apache Maven 3.10.0-rc-1 and maven-dependency-plugin 3.9.0. To re-record:
+#
+#   mvn org.apache.maven.plugins:maven-dependency-plugin:3.9.0:list \
+#       -DincludeScope=runtime -DoutputFile=/tmp/runtime.txt
+#   sed -e '1d' -e 's/ -- .*//' -e 's/ (optional)//' -e 's/^ *//' /tmp/runtime.txt | grep -v '^$' | sort
+#
+# groupId:artifactId:type[:classifier]:version:scope
+com.google.code.findbugs:jsr305:jar:3.0.2:compile
+commons-codec:commons-codec:jar:1.11:compile
+org.apache.commons:commons-lang3:jar:3.20.0:compile
+org.apache.httpcomponents:httpclient:jar:4.5.14:compile
+org.apache.httpcomponents:httpcore:jar:4.4.16:compile
+org.slf4j:slf4j-api:jar:2.0.17:runtime
+org.slf4j:slf4j-simple:jar:2.0.17:runtime

--- a/src/test/resources/ant/MavenParity/expected-test.txt
+++ b/src/test/resources/ant/MavenParity/expected-test.txt
@@ -1,0 +1,25 @@
+# What "mvn dependency:list -DincludeScope=test" reports for the pom.xml next to this file.
+#
+# Recorded with Apache Maven 3.10.0-rc-1 and maven-dependency-plugin 3.9.0. To re-record:
+#
+#   mvn org.apache.maven.plugins:maven-dependency-plugin:3.9.0:list \
+#       -DincludeScope=test -DoutputFile=/tmp/test.txt
+#   sed -e '1d' -e 's/ -- .*//' -e 's/ (optional)//' -e 's/^ *//' /tmp/test.txt | grep -v '^$' | sort
+#
+# groupId:artifactId:type[:classifier]:version:scope
+com.google.code.findbugs:jsr305:jar:3.0.2:compile
+commons-codec:commons-codec:jar:1.11:compile
+jakarta.servlet:jakarta.servlet-api:jar:6.1.0:provided
+org.apache.commons:commons-lang3:jar:3.20.0:compile
+org.apache.httpcomponents:httpclient:jar:4.5.14:compile
+org.apache.httpcomponents:httpcore:jar:4.4.16:compile
+org.apiguardian:apiguardian-api:jar:1.1.2:test
+org.junit.jupiter:junit-jupiter-api:jar:5.12.2:test
+org.junit.jupiter:junit-jupiter-engine:jar:5.12.2:test
+org.junit.jupiter:junit-jupiter-params:jar:5.12.2:test
+org.junit.jupiter:junit-jupiter:jar:5.12.2:test
+org.junit.platform:junit-platform-commons:jar:1.12.2:test
+org.junit.platform:junit-platform-engine:jar:1.12.2:test
+org.opentest4j:opentest4j:jar:1.3.0:test
+org.slf4j:slf4j-api:jar:2.0.17:runtime
+org.slf4j:slf4j-simple:jar:2.0.17:runtime

--- a/src/test/resources/ant/MavenParity/pom.xml
+++ b/src/test/resources/ant/MavenParity/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<!--
+  The fixture behind MavenParityTest. Every element here is load-bearing: an imported BOM, a
+  version taken from dependencyManagement, an exclusion, an optional dependency and one of every
+  scope. Changing it invalidates the recorded expectations next to this file.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.resolver.ant.it</groupId>
+  <artifactId>maven-parity</artifactId>
+  <version>1.0</version>
+  <packaging>jar</packaging>
+
+  <name>Maven parity fixture</name>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>5.12.2</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>3.20.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <!-- version comes from dependencyManagement -->
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <!-- transitive dependencies, one of them excluded -->
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.14</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>3.0.2</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>6.1.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>2.0.17</version>
+      <scope>runtime</scope>
+    </dependency>
+    <!-- version comes from the imported BOM -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/test/resources/ant/PomRepositories/pom.xml
+++ b/src/test/resources/ant/PomRepositories/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<!-- No parent and no dependencies, so that PomRepositoriesTest never reaches the network. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.resolver.ant.it</groupId>
+  <artifactId>pom-repositories</artifactId>
+  <version>1.0</version>
+  <packaging>jar</packaging>
+
+  <name>POM repositories fixture</name>
+
+  <repositories>
+    <repository>
+      <id>from-the-pom</id>
+      <url>https://example.invalid/repo</url>
+    </repository>
+  </repositories>
+</project>

--- a/src/test/resources/ant/PomRepositories/settings.xml
+++ b/src/test/resources/ant/PomRepositories/settings.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<!-- Empty on purpose: a mirror in the developer's own settings.xml would rewrite the repositories
+     PomRepositoriesTest asserts on. -->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+</settings>


### PR DESCRIPTION
Aligns what a POM contributes to a `<resolve>` with what the same POM contributes to a Maven build, and adds a test that measures the remaining difference instead of arguing about it.

Context is #105, which proposes removing POM support because "the way Ant reads POMs is not identical to Maven, but people's expectation is". Since that was filed against 1.3.1 the model half stopped being ours: 2.0.0 builds the effective model with Maven's own `maven-model-builder`, and the session defaults match Maven 3. What was left was a hand-written model-to-`CollectRequest` conversion that had drifted from `ArtifactDescriptorReaderDelegate`, the code Maven runs for the same job.

Changes, one per commit so any of them can be dropped:

- Delegate the conversion. The local copy pinned `optional` to `false` rather than carrying the model's tri-state value, so dependency management could no longer manage optionality; delegating fixes that and keeps the two in step for every other field as well.
- Set the collect request root artifact from the POM, as Maven does.
- Aggregate the POM's `<repositories>` into the repositories resolved against. They were used for parent and import resolution only, so a POM that builds under Maven could still fail to resolve here. This is the one behaviour change with a blast radius; Ant-side repositories stay dominant, and mirrors, proxies and authentication apply.

Worth calling out on that last one: because the effective model inherits the super POM, a POM contributes Maven Central even when it declares no repository of its own. That is what Maven does with the same POM, and `<mirrors>` and offline mode in `settings.xml` govern it the same way, but it does mean a build that today resolves only from an internal repository will also reach Central once it points the tasks at a POM. Happy to gate this commit behind a property, or drop it, if that trade is not the one we want.
- Unit tests over the conversion, a test pinning where the POM's repositories end up, and a parity test that resolves a fixture POM and compares it with recorded `mvn dependency:list` output per scope.

The fixture POM carries an imported BOM, a managed version, an exclusion, an optional dependency and one of every scope. Its expectations are recorded Maven output, and their headers carry the Maven version and the command that re-records them. Recording beats invoking Maven from the test because the CI matrix spans Maven 3.9, 3.10 and 4, and a live comparison would assert parity against whichever Maven happens to run the build.

Verified: `mvn verify` → 70 tests, green; `mvn verify -Prun-its` → green. Compile, runtime and test classpaths all match `dependency:list` with no difference.

Deliberately not changed here: the `<dependencies>`-level `<exclusions>` are still merged into managed dependencies, which Maven does not do. It is redundant rather than wrong, and undoing it is a semantic change to an Ant-only feature.

What this does not close: a version-less `<dependency>` against `<dependencyManagement>` still fails validation, the `<dependencyManagement>` type still only feeds `createPom`, and there is no `-P` equivalent. Those are separate.

*This change was created with AI assistance.*
