### PR TITLE
Move off the File-based Resolver API

### DIFF
--- a/src/main/java/org/apache/maven/resolver/internal/ant/AntModelResolver.java
+++ b/src/main/java/org/apache/maven/resolver/internal/ant/AntModelResolver.java
@@ -141,7 +141,7 @@ class AntModelResolver implements ModelResolver {
                     e);
         }
 
-        final File pomFile = pomArtifact.getFile();
+        final File pomFile = pomArtifact.getPath().toFile();
 
         return new FileModelSource(pomFile);
     }

--- a/src/main/java/org/apache/maven/resolver/internal/ant/AntRepoSys.java
+++ b/src/main/java/org/apache/maven/resolver/internal/ant/AntRepoSys.java
@@ -385,7 +385,7 @@ public class AntRepoSys {
             repoDir = getDefaultLocalRepoDir();
         }
 
-        return new org.eclipse.aether.repository.LocalRepository(repoDir);
+        return new org.eclipse.aether.repository.LocalRepository(repoDir.toPath());
     }
 
     private synchronized Settings getSettings() {
@@ -950,7 +950,7 @@ public class AntRepoSys {
 
         org.eclipse.aether.artifact.Artifact pomArtifact = new DefaultArtifact(
                         model.getGroupId(), model.getArtifactId(), "pom", model.getVersion())
-                .setFile(pomFile);
+                .setPath(pomFile.toPath());
         results.add(pomArtifact);
 
         for (Artifact artifact : artifacts.getArtifacts()) {
@@ -960,7 +960,7 @@ public class AntRepoSys {
                             artifact.getClassifier(),
                             artifact.getType(),
                             model.getVersion())
-                    .setFile(artifact.getFile());
+                    .setPath(artifact.getFile().toPath());
             results.add(buildArtifact);
         }
 

--- a/src/main/java/org/apache/maven/resolver/internal/ant/AntRepositoryListener.java
+++ b/src/main/java/org/apache/maven/resolver/internal/ant/AntRepositoryListener.java
@@ -39,12 +39,12 @@ class AntRepositoryListener extends AbstractRepositoryListener {
 
     @Override
     public void artifactInstalling(final RepositoryEvent event) {
-        task.log("Installing " + event.getArtifact().getFile() + " to " + event.getFile());
+        task.log("Installing " + event.getArtifact().getPath() + " to " + event.getPath());
     }
 
     @Override
     public void metadataInstalling(final RepositoryEvent event) {
-        task.log("Installing " + event.getMetadata() + " to " + event.getFile());
+        task.log("Installing " + event.getMetadata() + " to " + event.getPath());
     }
 
     @Override
@@ -65,8 +65,8 @@ class AntRepositoryListener extends AbstractRepositoryListener {
 
         final StringBuilder buffer = new StringBuilder(256);
         buffer.append("The metadata ");
-        if (event.getMetadata().getFile() != null) {
-            buffer.append(event.getMetadata().getFile());
+        if (event.getMetadata().getPath() != null) {
+            buffer.append(event.getMetadata().getPath());
         } else {
             buffer.append(event.getMetadata());
         }

--- a/src/main/java/org/apache/maven/resolver/internal/ant/AntTransferListener.java
+++ b/src/main/java/org/apache/maven/resolver/internal/ant/AntTransferListener.java
@@ -20,6 +20,8 @@ package org.apache.maven.resolver.internal.ant;
 
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Locale;
 
 import org.apache.tools.ant.Project;
@@ -72,8 +74,8 @@ class AntTransferListener extends AbstractTransferListener {
             final String len = contentLength >= 1024 ? ((contentLength + 1023) / 1024) + " KB" : contentLength + " B";
 
             String throughput = "";
-            final long duration =
-                    System.currentTimeMillis() - event.getResource().getTransferStartTime();
+            final long duration = Duration.between(event.getResource().getStartTime(), Instant.now())
+                    .toMillis();
             if (duration > 0) {
                 final DecimalFormat format = new DecimalFormat("0.0", new DecimalFormatSymbols(Locale.ENGLISH));
                 final double kbPerSec = (contentLength / 1024.0) / (duration / 1000.0);

--- a/src/main/java/org/apache/maven/resolver/internal/ant/ProjectWorkspaceReader.java
+++ b/src/main/java/org/apache/maven/resolver/internal/ant/ProjectWorkspaceReader.java
@@ -19,6 +19,7 @@
 package org.apache.maven.resolver.internal.ant;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -66,7 +67,7 @@ public class ProjectWorkspaceReader implements WorkspaceReader {
             Model model = pom.getModel(pom);
             Artifact aetherArtifact =
                     new DefaultArtifact(model.getGroupId(), model.getArtifactId(), null, "pom", model.getVersion());
-            aetherArtifact = aetherArtifact.setFile(pom.getFile());
+            aetherArtifact = aetherArtifact.setPath(pom.getFile().toPath());
             String coords = coords(aetherArtifact);
             artifacts.put(coords, aetherArtifact);
         }
@@ -98,7 +99,7 @@ public class ProjectWorkspaceReader implements WorkspaceReader {
                         artifact.getType(),
                         pom.getVersion());
             }
-            aetherArtifact = aetherArtifact.setFile(artifact.getFile());
+            aetherArtifact = aetherArtifact.setPath(artifact.getFile().toPath());
 
             String coords = coords(aetherArtifact);
             artifacts.put(coords, aetherArtifact);
@@ -134,8 +135,20 @@ public class ProjectWorkspaceReader implements WorkspaceReader {
      */
     @Override
     public File findArtifact(Artifact artifact) {
-        artifact = artifacts.get(coords(artifact));
-        return (artifact != null) ? artifact.getFile() : null;
+        Path path = findArtifactPath(artifact);
+        return (path != null) ? path.toFile() : null;
+    }
+
+    /**
+     * Locates the file of the given artifact in the workspace.
+     *
+     * @param artifact the artifact to locate
+     * @return the associated path if found, or {@code null} if not registered
+     */
+    @Override
+    public Path findArtifactPath(Artifact artifact) {
+        Artifact found = artifacts.get(coords(artifact));
+        return (found != null) ? found.getPath() : null;
     }
 
     /**

--- a/src/main/java/org/apache/maven/resolver/internal/ant/tasks/Resolve.java
+++ b/src/main/java/org/apache/maven/resolver/internal/ant/tasks/Resolve.java
@@ -494,7 +494,7 @@ public class Resolve extends AbstractResolvingTask {
                 path = new org.apache.tools.ant.types.Path(getProject());
                 getProject().addReference(refid, path);
             }
-            File file = artifact.getFile();
+            File file = artifact.getPath().toFile();
             path.add(new FileResource(file.getParentFile(), file.getName()));
         }
     }
@@ -662,7 +662,7 @@ public class Resolve extends AbstractResolvingTask {
                     fileset.createInclude().setName(path);
                 }
 
-                File src = artifact.getFile();
+                File src = artifact.getPath().toFile();
                 File dst = new File(dir, path);
 
                 if (src.lastModified() != dst.lastModified() || src.length() != dst.length()) {
@@ -683,8 +683,8 @@ public class Resolve extends AbstractResolvingTask {
                     getProject().addReference(refid, resources);
                 }
 
-                FileResource resource = new FileResource(artifact.getFile());
-                resource.setBaseDir(session.getLocalRepository().getBasedir());
+                FileResource resource = new FileResource(artifact.getPath().toFile());
+                resource.setBaseDir(session.getLocalRepository().getBasePath().toFile());
                 resource.setProject(getProject());
                 resources.add(resource);
             }
@@ -803,7 +803,7 @@ public class Resolve extends AbstractResolvingTask {
                 buffer.append(artifact.getClassifier());
             }
 
-            String path = artifact.getFile().getAbsolutePath();
+            String path = artifact.getPath().toAbsolutePath().toString();
 
             getProject().setProperty(buffer.toString(), path);
         }

--- a/src/test/java/org/apache/maven/resolver/internal/ant/ProjectWorkspaceReaderTest.java
+++ b/src/test/java/org/apache/maven/resolver/internal/ant/ProjectWorkspaceReaderTest.java
@@ -28,11 +28,11 @@ import org.eclipse.aether.artifact.DefaultArtifact;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
 
 public class ProjectWorkspaceReaderTest {
     public static junit.framework.Test suite() {


### PR DESCRIPTION
Clears 18 of the 22 deprecation warnings the build emits, all of them from Resolver 2's File-to-Path migration: `Artifact.getFile`/`setFile`, `Metadata.getFile`, `RepositoryEvent.getFile`, `LocalRepository(File)`, `LocalRepository.getBasedir` and `TransferResource.getTransferStartTime`.

Ant's own types take `File`, so the conversion moves to the edge rather than disappearing. `ProjectWorkspaceReader` now answers `findArtifactPath` and derives `findArtifact` from it, which is the direction Resolver asks in.

A second commit takes `assertThat` from `org.hamcrest.MatcherAssert` instead of the deprecated `org.junit.Assert` alias. It is the same import under either JUnit, so it does not get in the way of #179.

The four warnings left are `org.apache.maven.model.building.ModelSource` in `AntModelResolver`, and they are not ours to fix: `ModelResolver.resolveModel` is declared to return that type, so implementing the interface warns whatever we do. They go away with the model builder, not before.

Verified: `mvn clean verify` → 58 tests, green, and the code warnings drop from 22 to 4; `mvn verify -Prun-its` → green. Transfer throughput and install messages are unchanged in the log, which is what the `TransferResource` and `RepositoryEvent` changes could have broken silently.

Independent of #182; the two touch different parts of `AntRepoSys` and merge either way round.

*This change was created with AI assistance.*
